### PR TITLE
feat: migrate lez-multisig-ffi to lez-multisig-framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+result

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,3 +117,71 @@ install(TARGETS ${PLUGIN_TARGET}
     PUBLIC_HEADER   DESTINATION include
 )
 install(FILES ${LEZ_MULTISIG_INCLUDE}/lez_multisig.h DESTINATION include)
+
+# ── UI Plugin target (IComponent for logos-app-poc) ──────────────────────────
+option(BUILD_UI_PLUGIN "Build the IComponent UI plugin for logos-app-poc" OFF)
+
+if(BUILD_UI_PLUGIN)
+    find_package(Qt6Widgets      REQUIRED)
+    find_package(Qt6QuickWidgets REQUIRED)
+
+    # component-interfaces (IComponent.h)
+    find_package(component-interfaces QUIET)
+    if(NOT component-interfaces_FOUND)
+        add_library(component-interfaces INTERFACE)
+        target_include_directories(component-interfaces INTERFACE
+            "${CMAKE_CURRENT_SOURCE_DIR}/interfaces"
+        )
+    endif()
+
+    set(UI_TARGET lez_multisig_ui)
+
+    add_library(${UI_TARGET} SHARED
+        src/MultisigUIComponent.cpp
+        src/lez_multisig_module.cpp
+        src/proposal_list_model.cpp
+        src/registry_bridge.cpp
+        qml/qml.qrc
+    )
+
+    target_include_directories(${UI_TARGET} PRIVATE
+        src
+        "${LEZ_MULTISIG_INCLUDE}"
+        "${LEZ_REGISTRY_INCLUDE}"
+    )
+
+    target_compile_definitions(${UI_TARGET} PRIVATE
+        LEZ_MULTISIG_UI_BUILD
+        LEZ_MULTISIG_UI_METADATA_FILE="${CMAKE_CURRENT_SOURCE_DIR}/ui_metadata.json"
+    )
+
+    target_link_libraries(${UI_TARGET} PRIVATE
+        Qt6::Core
+        Qt6::Widgets
+        Qt6::Quick
+        Qt6::Qml
+        Qt6::QuickWidgets
+        Qt6::RemoteObjects
+        Qt6::Concurrent
+        logos_cpp_sdk
+        logos_core
+        lez_multisig_ffi
+        component-interfaces
+    )
+
+    if(APPLE)
+        set_target_properties(${UI_TARGET} PROPERTIES
+            BUILD_RPATH   "@loader_path"
+            INSTALL_RPATH "@loader_path"
+        )
+    elseif(UNIX)
+        set_target_properties(${UI_TARGET} PROPERTIES
+            BUILD_RPATH   "$ORIGIN"
+            INSTALL_RPATH "$ORIGIN"
+        )
+    endif()
+
+    install(TARGETS ${UI_TARGET}
+        LIBRARY DESTINATION lib
+    )
+endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.16)
+project(LogosLezMultisigApp LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Quick QuickWidgets)
+
+if(NOT DEFINED LOGOS_LIBLOGOS_ROOT)
+    message(FATAL_ERROR "LOGOS_LIBLOGOS_ROOT must be defined")
+endif()
+if(NOT DEFINED LOGOS_CPP_SDK_ROOT)
+    message(FATAL_ERROR "LOGOS_CPP_SDK_ROOT must be defined")
+endif()
+
+message(STATUS "Using logos-liblogos at: ${LOGOS_LIBLOGOS_ROOT}")
+message(STATUS "Using logos-cpp-sdk at: ${LOGOS_CPP_SDK_ROOT}")
+
+include_directories(
+    ${LOGOS_LIBLOGOS_ROOT}/include
+    ${LOGOS_CPP_SDK_ROOT}/include
+    ${LOGOS_CPP_SDK_ROOT}/include/cpp
+    ${LOGOS_CPP_SDK_ROOT}/include/core
+)
+
+link_directories(
+    ${LOGOS_LIBLOGOS_ROOT}/lib
+    ${LOGOS_CPP_SDK_ROOT}/lib
+)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_executable(logos-lez-multisig-app
+    main.cpp
+)
+
+target_link_libraries(logos-lez-multisig-app PRIVATE
+    Qt6::Core
+    Qt6::Widgets
+    Qt6::Quick
+    Qt6::QuickWidgets
+    logos_core
+    logos_sdk
+)
+
+if(APPLE)
+    set_target_properties(logos-lez-multisig-app PROPERTIES
+        INSTALL_RPATH "@executable_path/../lib"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+elseif(UNIX)
+    set_target_properties(logos-lez-multisig-app PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+endif()
+
+install(TARGETS logos-lez-multisig-app RUNTIME DESTINATION bin)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -34,6 +34,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_executable(logos-lez-multisig-app
     main.cpp
+    mainwindow.cpp
+    mainwindow.h
 )
 
 target_link_libraries(logos-lez-multisig-app PRIVATE

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,3 +1,5 @@
+#include "mainwindow.h"
+
 #include <QApplication>
 #include <QDir>
 #include <QDebug>
@@ -47,6 +49,9 @@ int main(int argc, char *argv[])
             qInfo() << "  -" << loadedPlugins[i];
         }
     }
+
+    MainWindow window;
+    window.show();
 
     std::cout << "LEZ Multisig App running — close window to exit." << std::endl;
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,0 +1,56 @@
+#include <QApplication>
+#include <QDir>
+#include <QDebug>
+#include <iostream>
+
+extern "C" {
+    void logos_core_set_plugins_dir(const char* plugins_dir);
+    void logos_core_start();
+    void logos_core_cleanup();
+    char** logos_core_get_loaded_plugins();
+    int logos_core_load_plugin(const char* plugin_name);
+}
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    // Set the plugins directory
+    QString pluginsDir = QDir::cleanPath(QCoreApplication::applicationDirPath() + "/../modules");
+    std::cout << "Setting plugins directory to: " << pluginsDir.toStdString() << std::endl;
+    logos_core_set_plugins_dir(pluginsDir.toUtf8().constData());
+
+    // Start the core
+    logos_core_start();
+    std::cout << "Logos Core started successfully!" << std::endl;
+
+    // Load capability_module first
+    std::cout << "Loading plugins in specified order..." << std::endl;
+    if (logos_core_load_plugin("capability_module")) {
+        std::cout << "Successfully loaded capability_module plugin" << std::endl;
+    } else {
+        std::cerr << "Failed to load capability_module plugin" << std::endl;
+    }
+
+    // Then load lez_multisig_module
+    if (logos_core_load_plugin("lez_multisig_module")) {
+        std::cout << "Successfully loaded lez_multisig_module plugin" << std::endl;
+    } else {
+        std::cerr << "Failed to load lez_multisig_module plugin" << std::endl;
+    }
+
+    // Print loaded plugins
+    char** loadedPlugins = logos_core_get_loaded_plugins();
+    if (loadedPlugins) {
+        qInfo() << "Currently loaded plugins:";
+        for (int i = 0; loadedPlugins[i] != nullptr; i++) {
+            qInfo() << "  -" << loadedPlugins[i];
+        }
+    }
+
+    std::cout << "LEZ Multisig App running — close window to exit." << std::endl;
+
+    int result = app.exec();
+    logos_core_cleanup();
+    return result;
+}

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -11,8 +11,6 @@
 #include <QQmlEngine>
 #include <QQmlContext>
 #include <QUrl>
-#include "../src/lez_multisig_module.h"
-#include "../src/proposal_list_model.h"
 #include <QFile>
 
 MainWindow::MainWindow(QWidget *parent)
@@ -63,13 +61,9 @@ void MainWindow::setupUi()
         qmlUrl = QUrl("qrc:/qml/LezMultisigView.qml");
     }
 
-    // Create and register the multisig module for QML access
-    auto* module = new LezMultisigModule(this);
-    auto* model = module->proposalModel();
-    m_quickWidget->engine()->rootContext()->setContextProperty(
-        QStringLiteral("lezMultisigModule"), module);
-    m_quickWidget->engine()->rootContext()->setContextProperty(
-        QStringLiteral("lezMultisigModel"), model ? model : new QObject(this));
+    // Note: lezMultisigModule and lezMultisigModel context properties
+    // are set by the plugin when loaded via logoscore.
+    // In standalone mode, QML falls back to demo data gracefully.
 
     m_quickWidget->setSource(qmlUrl);
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1,0 +1,86 @@
+#include "mainwindow.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QPluginLoader>
+#include <QDebug>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QDir>
+#include <QQuickWidget>
+#include <QQmlEngine>
+#include <QQmlContext>
+#include <QUrl>
+#include <QFile>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    setupUi();
+}
+
+MainWindow::~MainWindow()
+{
+}
+
+void MainWindow::setupUi()
+{
+    QString pluginExtension;
+    #if defined(Q_OS_WIN)
+        pluginExtension = ".dll";
+    #elif defined(Q_OS_MAC)
+        pluginExtension = ".dylib";
+    #else
+        pluginExtension = ".so";
+    #endif
+
+    QString pluginPath = QCoreApplication::applicationDirPath() + "/../modules/liblez_multisig_module" + pluginExtension;
+    QPluginLoader loader(pluginPath);
+
+    if (loader.load()) {
+        QObject* plugin = loader.instance();
+        if (plugin) {
+            qInfo() << "LEZ Multisig module plugin loaded successfully";
+        }
+    } else {
+        qWarning() << "Failed to load LEZ Multisig module from:" << pluginPath;
+        qWarning() << "Error:" << loader.errorString();
+    }
+
+    m_quickWidget = new QQuickWidget(this);
+    m_quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+
+    QString qmlDir = QCoreApplication::applicationDirPath() + "/../qml";
+    m_quickWidget->engine()->addImportPath(qmlDir);
+
+    QUrl qmlUrl;
+    QString localQml = qmlDir + "/LezMultisigView.qml";
+    if (QFile::exists(localQml)) {
+        qmlUrl = QUrl::fromLocalFile(localQml);
+    } else {
+        qmlUrl = QUrl("qrc:/qml/LezMultisigView.qml");
+    }
+
+    m_quickWidget->setSource(qmlUrl);
+
+    if (m_quickWidget->status() == QQuickWidget::Error) {
+        qWarning() << "QML loading errors:";
+        for (const auto &error : m_quickWidget->errors()) {
+            qWarning() << "  " << error.toString();
+        }
+        QWidget* fallbackWidget = new QWidget(this);
+        QVBoxLayout* layout = new QVBoxLayout(fallbackWidget);
+        QLabel* messageLabel = new QLabel("LEZ Multisig QML view failed to load", fallbackWidget);
+        QFont font = messageLabel->font();
+        font.setPointSize(14);
+        messageLabel->setFont(font);
+        messageLabel->setAlignment(Qt::AlignCenter);
+        layout->addWidget(messageLabel);
+        setCentralWidget(fallbackWidget);
+    } else {
+        setCentralWidget(m_quickWidget);
+    }
+
+    setWindowTitle("LEZ Multisig");
+    resize(800, 600);
+}

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -11,6 +11,8 @@
 #include <QQmlEngine>
 #include <QQmlContext>
 #include <QUrl>
+#include "../src/lez_multisig_module.h"
+#include "../src/proposal_list_model.h"
 #include <QFile>
 
 MainWindow::MainWindow(QWidget *parent)
@@ -60,6 +62,14 @@ void MainWindow::setupUi()
     } else {
         qmlUrl = QUrl("qrc:/qml/LezMultisigView.qml");
     }
+
+    // Create and register the multisig module for QML access
+    auto* module = new LezMultisigModule(this);
+    auto* model = module->proposalModel();
+    m_quickWidget->engine()->rootContext()->setContextProperty(
+        QStringLiteral("lezMultisigModule"), module);
+    m_quickWidget->engine()->rootContext()->setContextProperty(
+        QStringLiteral("lezMultisigModel"), model ? model : new QObject(this));
 
     m_quickWidget->setSource(qmlUrl);
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -37,9 +37,10 @@ void MainWindow::setupUi()
     QString pluginPath = QCoreApplication::applicationDirPath() + "/../modules/liblez_multisig_module" + pluginExtension;
     QPluginLoader loader(pluginPath);
 
+    QObject* pluginObj = nullptr;
     if (loader.load()) {
-        QObject* plugin = loader.instance();
-        if (plugin) {
+        pluginObj = loader.instance();
+        if (pluginObj) {
             qInfo() << "LEZ Multisig module plugin loaded successfully";
         }
     } else {
@@ -61,9 +62,21 @@ void MainWindow::setupUi()
         qmlUrl = QUrl("qrc:/qml/LezMultisigView.qml");
     }
 
-    // Note: lezMultisigModule and lezMultisigModel context properties
-    // are set by the plugin when loaded via logoscore.
-    // In standalone mode, QML falls back to demo data gracefully.
+    // Expose plugin to QML as context properties
+    if (pluginObj) {
+        m_quickWidget->engine()->rootContext()->setContextProperty(
+            QStringLiteral("lezMultisigModule"), pluginObj);
+        // Find the ProposalListModel child object
+        QObject* model = pluginObj->findChild<QObject*>(QStringLiteral("proposalListModel"));
+        if (model) {
+            m_quickWidget->engine()->rootContext()->setContextProperty(
+                QStringLiteral("lezMultisigModel"), model);
+            qInfo() << "ProposalListModel exposed to QML";
+        } else {
+            qInfo() << "ProposalListModel not found - QML will use demo data";
+        }
+        qInfo() << "Context properties set for QML";
+    }
 
     m_quickWidget->setSource(qmlUrl);
 

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -1,0 +1,21 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+
+class QQuickWidget;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+private:
+    void setupUi();
+    QQuickWidget *m_quickWidget = nullptr;
+};
+
+#endif // MAINWINDOW_H

--- a/flake.lock
+++ b/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "lez-multisig-ffi",
-        "lastModified": 1771779991,
-        "narHash": "sha256-LAmqyu5Pye6/ZAIqSDB43ZtWHzV2mwODNP2kf873UEk=",
+        "lastModified": 1772007798,
+        "narHash": "sha256-xY2xbuPE693Y1fQ00y1tXxJkkshxIKbWlPZ4+2DRtHc=",
         "owner": "jimmy-claw",
         "repo": "lez-multisig",
-        "rev": "93cd70d4732fe4b23d364846435ac17ac4656f87",
+        "rev": "d1a4f88dc70ec8e739cfbd51d7ffeaee2ab2a997",
         "type": "github"
       },
       "original": {
         "dir": "lez-multisig-ffi",
         "owner": "jimmy-claw",
-        "ref": "jimmy/nssa-framework-migration",
+        "ref": "jimmy/regen-multisig-ffi-20",
         "repo": "lez-multisig",
         "type": "github"
       }
@@ -350,11 +350,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771423170,
-        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771816254,
-        "narHash": "sha256-vkp3iTF6QmHMvL+34DI93IiMPjS2lqcMlA1fl7nXVsQ=",
+        "lastModified": 1771988922,
+        "narHash": "sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "085bdbf5dde5477538e4c87d1684b6c6df56c0ad",
+        "rev": "f4443dc3f0b6c5e6b77d923156943ce816d1fcb9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1771796463,
-        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
+        "lastModified": 1772080396,
+        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
+        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
         "type": "github"
       },
       "original": {
@@ -37,19 +37,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "dir": "lez-multisig-ffi",
-        "lastModified": 1772014708,
-        "narHash": "sha256-rImGqowH0WKm9vpHhVljO7JPhBZQhUpaT1N1X0gNw2w=",
+        "lastModified": 1772123671,
+        "narHash": "sha256-wxnGmugVni2fTgytdTUXcFsKzc+azguTDqEwKNXp+1o=",
         "owner": "jimmy-claw",
-        "repo": "lez-multisig",
-        "rev": "89b500d374c3cf0278a1e54d3fc037b3fa444d59",
+        "repo": "lez-multisig-framework",
+        "rev": "7f96e3ecd124c945de23a759ea146b8f7c7fc3bb",
         "type": "github"
       },
       "original": {
-        "dir": "lez-multisig-ffi",
         "owner": "jimmy-claw",
-        "ref": "jimmy/nssa-framework-migration",
-        "repo": "lez-multisig",
+        "ref": "jimmy/add-nix-flake",
+        "repo": "lez-multisig-framework",
         "type": "github"
       }
     },
@@ -513,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771988922,
-        "narHash": "sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ=",
+        "lastModified": 1772075164,
+        "narHash": "sha256-93XcvAt+6p7aAq1ERlxD2T17zLGoYGo64KJYasGcpgc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f4443dc3f0b6c5e6b77d923156943ce816d1fcb9",
+        "rev": "07601339b15fa6810541c0e7dc2f3664d92a7ad0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "lez-multisig-ffi",
-        "lastModified": 1772007798,
-        "narHash": "sha256-xY2xbuPE693Y1fQ00y1tXxJkkshxIKbWlPZ4+2DRtHc=",
+        "lastModified": 1772014708,
+        "narHash": "sha256-rImGqowH0WKm9vpHhVljO7JPhBZQhUpaT1N1X0gNw2w=",
         "owner": "jimmy-claw",
         "repo": "lez-multisig",
-        "rev": "d1a4f88dc70ec8e739cfbd51d7ffeaee2ab2a997",
+        "rev": "89b500d374c3cf0278a1e54d3fc037b3fa444d59",
         "type": "github"
       },
       "original": {
         "dir": "lez-multisig-ffi",
         "owner": "jimmy-claw",
-        "ref": "jimmy/regen-multisig-ffi-20",
+        "ref": "jimmy/nssa-framework-migration",
         "repo": "lez-multisig",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,49 @@
         "type": "github"
       }
     },
-    "lez-registry-ffi": {
+    "crane_2": {
+      "locked": {
+        "lastModified": 1771796463,
+        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "lez-multisig-ffi": {
       "inputs": {
         "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "dir": "lez-multisig-ffi",
+        "lastModified": 1771779991,
+        "narHash": "sha256-LAmqyu5Pye6/ZAIqSDB43ZtWHzV2mwODNP2kf873UEk=",
+        "owner": "jimmy-claw",
+        "repo": "lez-multisig",
+        "rev": "93cd70d4732fe4b23d364846435ac17ac4656f87",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lez-multisig-ffi",
+        "owner": "jimmy-claw",
+        "ref": "jimmy/nssa-framework-migration",
+        "repo": "lez-multisig",
+        "type": "github"
+      }
+    },
+    "lez-registry-ffi": {
+      "inputs": {
+        "crane": "crane_2",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "dir": "lez-registry-ffi",
@@ -88,7 +126,7 @@
     },
     "logos-cpp-sdk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1761230734,
@@ -106,7 +144,7 @@
     },
     "logos-cpp-sdk_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1761230734,
@@ -124,7 +162,7 @@
     },
     "logos-cpp-sdk_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1770132997,
@@ -142,7 +180,7 @@
     },
     "logos-cpp-sdk_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1761230734,
@@ -160,7 +198,7 @@
     },
     "logos-cpp-sdk_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1761230734,
@@ -178,7 +216,7 @@
     },
     "logos-cpp-sdk_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1767724329,
@@ -196,7 +234,7 @@
     },
     "logos-cpp-sdk_7": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1767724329,
@@ -328,16 +366,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1771423170,
+        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -438,8 +476,25 @@
         "type": "github"
       }
     },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "lez-multisig-ffi": "lez-multisig-ffi",
         "lez-registry-ffi": "lez-registry-ffi",
         "logos-capability-module": "logos-capability-module",
         "logos-cpp-sdk": "logos-cpp-sdk_3",
@@ -451,6 +506,27 @@
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "lez-multisig-ffi",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771816254,
+        "narHash": "sha256-vkp3iTF6QmHMvL+34DI93IiMPjS2lqcMlA1fl7nXVsQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "085bdbf5dde5477538e4c87d1684b6c6df56c0ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "lez-registry-ffi",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,477 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1771796463,
+        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "lez-registry-ffi": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "dir": "lez-registry-ffi",
+        "lastModified": 1771850688,
+        "narHash": "sha256-5wtPe8D2wFyFyYlCHwoR82TWoyhVpYQFJG5x6cVX/BE=",
+        "owner": "jimmy-claw",
+        "repo": "lez-registry",
+        "rev": "981b2debea245faedbc938129a3e2767496ea292",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lez-registry-ffi",
+        "owner": "jimmy-claw",
+        "repo": "lez-registry",
+        "type": "github"
+      }
+    },
+    "logos-capability-module": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk",
+        "logos-liblogos": "logos-liblogos",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767809111,
+        "narHash": "sha256-jehjsB+BpDJlVu3I7x+vFVOdXmy9MDmFTJtRqzFUONo=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "7b35383e0aa4e28a4633ed18a87efb57636939b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-capability-module_2": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_4",
+        "logos-liblogos": "logos-liblogos_3",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767809111,
+        "narHash": "sha256-jehjsB+BpDJlVu3I7x+vFVOdXmy9MDmFTJtRqzFUONo=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "7b35383e0aa4e28a4633ed18a87efb57636939b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1761230734,
+        "narHash": "sha256-CMRUwXH7pJZ1OI6bd/TDDDXKqQ1tQZHQEOOwK8TgYHI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b143922c190df00bb3835441c9f0075cb28283b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1761230734,
+        "narHash": "sha256-CMRUwXH7pJZ1OI6bd/TDDDXKqQ1tQZHQEOOwK8TgYHI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b143922c190df00bb3835441c9f0075cb28283b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1770132997,
+        "narHash": "sha256-Iv0QMXMD6kf+y2Qx37jXR7Ik6h1dqOzuxBzCdc5S6KA=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "30ef7986f4b65b7dcf43af84bb073233b1b77821",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1761230734,
+        "narHash": "sha256-CMRUwXH7pJZ1OI6bd/TDDDXKqQ1tQZHQEOOwK8TgYHI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b143922c190df00bb3835441c9f0075cb28283b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_5": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1761230734,
+        "narHash": "sha256-CMRUwXH7pJZ1OI6bd/TDDDXKqQ1tQZHQEOOwK8TgYHI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "4b143922c190df00bb3835441c9f0075cb28283b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_6": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1767724329,
+        "narHash": "sha256-UPkqxqxbKwU5Dmu00TnjiJVXUmfVylF3p1qziEuYwIE=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "32f1d7080d784ff044d91d076ef2f0c7305d4784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1767724329,
+        "narHash": "sha256-UPkqxqxbKwU5Dmu00TnjiJVXUmfVylF3p1qziEuYwIE=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "32f1d7080d784ff044d91d076ef2f0c7305d4784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-liblogos": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_2",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761845775,
+        "narHash": "sha256-ulK8xq05ejK6qIgZ7WtWb/MJt2rk5BKfDA2z7mM3wq8=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "a92c2c1268bc70764c8f73c7bce07d21024f5af9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_2": {
+      "inputs": {
+        "logos-capability-module": "logos-capability-module_2",
+        "logos-cpp-sdk": "logos-cpp-sdk_6",
+        "logos-module": "logos-module",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770837874,
+        "narHash": "sha256-wr75lv1q4U1FS5+l/6ypwzJFJe06l2RyUvx1npoRS88=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "e3741c01fd3abf6b7bd9ff2fa8edf89c41fc0cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_3": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_5",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761845775,
+        "narHash": "sha256-ulK8xq05ejK6qIgZ7WtWb/MJt2rk5BKfDA2z7mM3wq8=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "a92c2c1268bc70764c8f73c7bce07d21024f5af9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-module": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_7",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-module",
+          "logos-cpp-sdk",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770062426,
+        "narHash": "sha256-zc7ZxDTlqOCYGyEHhrTA/7GS1EWh7+4amdPUKh+gGds=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "f7ee69d9ad9f27c84f04f59896e9194125e951dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771423170,
+        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "lez-registry-ffi": "lez-registry-ffi",
+        "logos-capability-module": "logos-capability-module",
+        "logos-cpp-sdk": "logos-cpp-sdk_3",
+        "logos-liblogos": "logos-liblogos_2",
+        "nixpkgs": [
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "lez-registry-ffi",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771816254,
+        "narHash": "sha256-vkp3iTF6QmHMvL+34DI93IiMPjS2lqcMlA1fl7nXVsQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "085bdbf5dde5477538e4c87d1684b6c6df56c0ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    # NOTE: lez-multisig-ffi does not exist yet in the lez-multisig repo.
-    # Once it's created (similar to lez-registry-ffi), uncomment and point here:
-    # lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi";
-
-    # Re-use lez-registry-ffi for the registry_bridge header
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 
@@ -23,6 +19,7 @@
       logos-cpp-sdk,
       logos-liblogos,
       logos-capability-module,
+      lez-multisig-ffi,
       lez-registry-ffi,
       ...
     }:
@@ -33,63 +30,24 @@
         logosSdk = logos-cpp-sdk.packages.${system}.default;
         logosLiblogos = logos-liblogos.packages.${system}.default;
         logosCapabilityModule = logos-capability-module.packages.${system}.default;
+        lezMultisigFfi = lez-multisig-ffi.packages.${system}.default;
         lezRegistryFfi = lez-registry-ffi.packages.${system}.default;
       });
     in
     {
-      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosCapabilityModule, lezRegistryFfi }:
+      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi }:
         let
           common = import ./nix/default.nix {
             inherit pkgs logosSdk logosLiblogos;
           };
           src = ./.;
 
-          # Stub FFI: creates a minimal .so and header so the build can link
-          # Replace with the real lez-multisig-ffi input once it exists
-          lezMultisigFfiStub = pkgs.stdenv.mkDerivation {
-            pname = "lez-multisig-ffi-stub";
-            version = "0.0.0";
-            dontUnpack = true;
-            buildPhase = ''
-              # Create a stub shared library
-              cat > stub.c << 'EOF'
-              /* Stub implementations — replace with real lez-multisig-ffi */
-              const char* lez_multisig_version(void) { return "stub-0.0.0"; }
-              void lez_multisig_free_string(char* s) { (void)s; }
-              EOF
-              $CC -shared -o liblez_multisig_ffi.so stub.c
-
-              # Create a minimal header
-              mkdir -p include
-              cat > include/lez_multisig.h << 'HEOF'
-              #ifndef LEZ_MULTISIG_H
-              #define LEZ_MULTISIG_H
-              #ifdef __cplusplus
-              extern "C" {
-              #endif
-              const char* lez_multisig_version(void);
-              void lez_multisig_free_string(char* s);
-              #ifdef __cplusplus
-              }
-              #endif
-              #endif
-              HEOF
-            '';
-            installPhase = ''
-              mkdir -p $out/lib $out/include
-              cp liblez_multisig_ffi.so $out/lib/
-              cp include/lez_multisig.h $out/include/
-            '';
-          };
-
-          lezMultisigFfi = lezMultisigFfiStub;
-
           lib = import ./nix/lib.nix {
             inherit pkgs common src logosSdk logosLiblogos lezMultisigFfi lezRegistryFfi;
           };
 
           app = import ./nix/app.nix {
-            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi;
+            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi;
             lezMultisigModule = lib;
           };
         in
@@ -99,7 +57,7 @@
         }
       );
 
-      devShells = forAllSystems ({ pkgs, logosSdk, logosLiblogos, lezRegistryFfi, ... }: {
+      devShells = forAllSystems ({ pkgs, logosSdk, logosLiblogos, lezMultisigFfi, lezRegistryFfi, ... }: {
         default = pkgs.mkShell {
           nativeBuildInputs = [
             pkgs.cmake
@@ -118,9 +76,9 @@
           shellHook = ''
             export LOGOS_CPP_SDK_ROOT="${logosSdk}"
             export LOGOS_LIBLOGOS_ROOT="${logosLiblogos}"
-            export LEZ_REGISTRY_INCLUDE="${lezRegistryFfi}/include"
+            export LEZ_MULTISIG_FFI_ROOT="${lezMultisigFfi}"
+            export LEZ_REGISTRY_FFI_ROOT="${lezRegistryFfi}"
             echo "LEZ Multisig Module development environment"
-            echo "NOTE: lez-multisig-ffi not yet available — using stubs"
           '';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework/jimmy/add-nix-flake";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,128 @@
+{
+  description = "logos-lez-multisig-module — Qt6 Logos Core plugin and standalone app for LEZ Multisig governance";
+
+  inputs = {
+    nixpkgs.follows = "logos-liblogos/nixpkgs";
+
+    logos-liblogos.url = "github:logos-co/logos-liblogos";
+    logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
+    logos-capability-module.url = "github:logos-co/logos-capability-module";
+
+    # NOTE: lez-multisig-ffi does not exist yet in the lez-multisig repo.
+    # Once it's created (similar to lez-registry-ffi), uncomment and point here:
+    # lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi";
+
+    # Re-use lez-registry-ffi for the registry_bridge header
+    lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      logos-cpp-sdk,
+      logos-liblogos,
+      logos-capability-module,
+      lez-registry-ffi,
+      ...
+    }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+        logosSdk = logos-cpp-sdk.packages.${system}.default;
+        logosLiblogos = logos-liblogos.packages.${system}.default;
+        logosCapabilityModule = logos-capability-module.packages.${system}.default;
+        lezRegistryFfi = lez-registry-ffi.packages.${system}.default;
+      });
+    in
+    {
+      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosCapabilityModule, lezRegistryFfi }:
+        let
+          common = import ./nix/default.nix {
+            inherit pkgs logosSdk logosLiblogos;
+          };
+          src = ./.;
+
+          # Stub FFI: creates a minimal .so and header so the build can link
+          # Replace with the real lez-multisig-ffi input once it exists
+          lezMultisigFfiStub = pkgs.stdenv.mkDerivation {
+            pname = "lez-multisig-ffi-stub";
+            version = "0.0.0";
+            dontUnpack = true;
+            buildPhase = ''
+              # Create a stub shared library
+              cat > stub.c << 'EOF'
+              /* Stub implementations — replace with real lez-multisig-ffi */
+              const char* lez_multisig_version(void) { return "stub-0.0.0"; }
+              void lez_multisig_free_string(char* s) { (void)s; }
+              EOF
+              $CC -shared -o liblez_multisig_ffi.so stub.c
+
+              # Create a minimal header
+              mkdir -p include
+              cat > include/lez_multisig.h << 'HEOF'
+              #ifndef LEZ_MULTISIG_H
+              #define LEZ_MULTISIG_H
+              #ifdef __cplusplus
+              extern "C" {
+              #endif
+              const char* lez_multisig_version(void);
+              void lez_multisig_free_string(char* s);
+              #ifdef __cplusplus
+              }
+              #endif
+              #endif
+              HEOF
+            '';
+            installPhase = ''
+              mkdir -p $out/lib $out/include
+              cp liblez_multisig_ffi.so $out/lib/
+              cp include/lez_multisig.h $out/include/
+            '';
+          };
+
+          lezMultisigFfi = lezMultisigFfiStub;
+
+          lib = import ./nix/lib.nix {
+            inherit pkgs common src logosSdk logosLiblogos lezMultisigFfi lezRegistryFfi;
+          };
+
+          app = import ./nix/app.nix {
+            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi;
+            lezMultisigModule = lib;
+          };
+        in
+        {
+          inherit lib app;
+          default = lib;
+        }
+      );
+
+      devShells = forAllSystems ({ pkgs, logosSdk, logosLiblogos, lezRegistryFfi, ... }: {
+        default = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.pkg-config
+          ];
+          buildInputs = [
+            pkgs.qt6.qtbase
+            pkgs.qt6.qtremoteobjects
+            pkgs.qt6.qtdeclarative
+            pkgs.zstd
+            pkgs.krb5
+            pkgs.abseil-cpp
+          ];
+
+          shellHook = ''
+            export LOGOS_CPP_SDK_ROOT="${logosSdk}"
+            export LOGOS_LIBLOGOS_ROOT="${logosLiblogos}"
+            export LEZ_REGISTRY_INCLUDE="${lezRegistryFfi}/include"
+            echo "LEZ Multisig Module development environment"
+            echo "NOTE: lez-multisig-ffi not yet available — using stubs"
+          '';
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -50,9 +50,13 @@
             inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi;
             lezMultisigModule = lib;
           };
+
+          ui = import ./nix/ui.nix {
+            inherit pkgs common src logosSdk logosLiblogos lezMultisigFfi lezRegistryFfi;
+          };
         in
         {
-          inherit lib app;
+          inherit lib app ui;
           default = lib;
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/regen-multisig-ffi-20";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/regen-multisig-ffi-20";
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
           };
 
           app = import ./nix/app.nix {
-            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi;
+            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi;
             lezMultisigModule = lib;
           };
         in

--- a/interfaces/IComponent.h
+++ b/interfaces/IComponent.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QObject>
+#include <QWidget>
+#include <QtPlugin>
+
+class LogosAPI;
+
+class IComponent {
+public:
+    virtual ~IComponent() = default;
+    virtual QWidget* createWidget(LogosAPI* logosAPI = nullptr) = 0;
+    virtual void destroyWidget(QWidget* widget) = 0;
+};
+
+#define IComponent_iid "com.logos.component.IComponent"
+Q_DECLARE_INTERFACE(IComponent, IComponent_iid)

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,26 @@
 {
-  "name": "liblez_multisig_module",
+  "name": "lez_multisig_module",
   "version": "0.1.0",
-  "description": "LEZ Multisig — M-of-N governance with registry integration",
+  "description": "LEZ Multisig \u2014 M-of-N governance with registry integration",
   "author": "jimmy-claw",
   "type": "blockchain",
-  "dependencies": ["capability_module"],
-  "include": ["liblez_multisig_ffi.so", "liblez_multisig_ffi.dylib", "liblez_registry_ffi.so", "liblez_registry_ffi.dylib"],
+  "dependencies": [
+    "capability_module"
+  ],
+  "include": [
+    "liblez_multisig_ffi.so",
+    "liblez_multisig_ffi.dylib",
+    "liblez_registry_ffi.so",
+    "liblez_registry_ffi.dylib"
+  ],
   "ui": {
     "component": "LezMultisigView",
     "qmlUrl": "qrc:/lez-multisig/LezMultisigView.qml",
-    "contextProperties": ["lezMultisigModel", "lezMultisigModule"],
+    "contextProperties": [
+      "lezMultisigModel",
+      "lezMultisigModule"
+    ],
     "title": "LEZ Multisig",
-    "icon": "🔐"
+    "icon": "\ud83d\udd10"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,3 +1,16 @@
 {
-    "Keys": ["org.logos.ilezmultisigmodule"]
+  "name": "liblez_multisig_module",
+  "version": "0.1.0",
+  "description": "LEZ Multisig — M-of-N governance with registry integration",
+  "author": "jimmy-claw",
+  "type": "blockchain",
+  "dependencies": ["capability_module"],
+  "include": ["liblez_multisig_ffi.so", "liblez_multisig_ffi.dylib", "liblez_registry_ffi.so", "liblez_registry_ffi.dylib"],
+  "ui": {
+    "component": "LezMultisigView",
+    "qmlUrl": "qrc:/lez-multisig/LezMultisigView.qml",
+    "contextProperties": ["lezMultisigModel", "lezMultisigModule"],
+    "title": "LEZ Multisig",
+    "icon": "🔐"
+  }
 }

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -1,0 +1,180 @@
+# Builds the logos-lez-multisig-app standalone application
+{ pkgs, common, src, logosLiblogos, logosSdk, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi, lezMultisigModule }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "logos-lez-multisig-app";
+  version = common.version;
+
+  inherit src;
+  inherit (common) buildInputs cmakeFlags meta env;
+
+  nativeBuildInputs = common.nativeBuildInputs ++ [ pkgs.patchelf pkgs.removeReferencesTo ];
+
+  qtLibPath = pkgs.lib.makeLibraryPath (
+    [
+      pkgs.qt6.qtbase
+      pkgs.qt6.qtremoteobjects
+      pkgs.qt6.qtdeclarative
+      pkgs.zstd
+      pkgs.krb5
+      pkgs.zlib
+      pkgs.glib
+      pkgs.stdenv.cc.cc
+      pkgs.freetype
+      pkgs.fontconfig
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      pkgs.libglvnd
+      pkgs.mesa.drivers
+      pkgs.xorg.libX11
+      pkgs.xorg.libXext
+      pkgs.xorg.libXrender
+      pkgs.xorg.libXrandr
+      pkgs.xorg.libXcursor
+      pkgs.xorg.libXi
+      pkgs.xorg.libXfixes
+      pkgs.xorg.libxcb
+    ]
+  );
+  qtPluginPath = "${pkgs.qt6.qtbase}/lib/qt-6/plugins";
+
+  dontWrapQtApps = false;
+  dontStrip = true;
+
+  qtWrapperArgs = [
+    "--prefix" "LD_LIBRARY_PATH" ":" qtLibPath
+    "--prefix" "QT_PLUGIN_PATH" ":" qtPluginPath
+    "--set" "QT_QUICK_BACKEND" "software"
+  ];
+
+  preConfigure = ''
+    runHook prePreConfigure
+
+    # Copy logos-cpp-sdk headers
+    mkdir -p ./logos-cpp-sdk/include/cpp
+    cp -r ${logosSdk}/include/cpp/* ./logos-cpp-sdk/include/cpp/
+    mkdir -p ./logos-cpp-sdk/include/core
+    cp -r ${logosSdk}/include/core/* ./logos-cpp-sdk/include/core/
+
+    # Copy SDK library
+    mkdir -p ./logos-cpp-sdk/lib
+    if [ -f "${logosSdk}/lib/liblogos_sdk.so" ]; then
+      cp "${logosSdk}/lib/liblogos_sdk.so" ./logos-cpp-sdk/lib/
+    elif [ -f "${logosSdk}/lib/liblogos_sdk.a" ]; then
+      cp "${logosSdk}/lib/liblogos_sdk.a" ./logos-cpp-sdk/lib/
+    fi
+
+    runHook postPreConfigure
+  '';
+
+  preFixup = ''
+    runHook prePreFixup
+
+    export QT_PLUGIN_PATH="${pkgs.qt6.qtbase}/lib/qt-6/plugins"
+    export QML_IMPORT_PATH="${pkgs.qt6.qtbase}/lib/qt-6/qml"
+
+    find $out -type f -executable -exec sh -c '
+      if file "$1" | grep -q "ELF.*executable"; then
+        if patchelf --print-rpath "$1" 2>/dev/null | grep -q "/build/"; then
+          patchelf --remove-rpath "$1" 2>/dev/null || true
+        fi
+        if echo "$1" | grep -q "/logos-lez-multisig-app$"; then
+          patchelf --set-rpath "$out/lib" "$1" 2>/dev/null || true
+        fi
+      fi
+    ' _ {} \;
+
+    find $out -name "*.so" -exec sh -c '
+      if patchelf --print-rpath "$1" 2>/dev/null | grep -q "/build/"; then
+        patchelf --remove-rpath "$1" 2>/dev/null || true
+      fi
+    ' _ {} \;
+
+    runHook prePostFixup
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    echo "Configuring logos-lez-multisig-app..."
+    echo "liblogos: ${logosLiblogos}"
+    echo "cpp-sdk: ${logosSdk}"
+    echo "capability-module: ${logosCapabilityModule}"
+    echo "lez-multisig-ffi: ${lezMultisigFfi}"
+    echo "lez-multisig-module: ${lezMultisigModule}"
+
+    test -d "${logosLiblogos}" || (echo "liblogos not found" && exit 1)
+    test -d "${logosSdk}" || (echo "cpp-sdk not found" && exit 1)
+    test -d "${logosCapabilityModule}" || (echo "capability-module not found" && exit 1)
+    test -d "${lezMultisigModule}" || (echo "lez-multisig-module not found" && exit 1)
+
+    cmake -S app -B build \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
+      -DCMAKE_INSTALL_RPATH="" \
+      -DCMAKE_SKIP_BUILD_RPATH=TRUE \
+      -DLOGOS_LIBLOGOS_ROOT=${logosLiblogos} \
+      -DLOGOS_CPP_SDK_ROOT=$(pwd)/logos-cpp-sdk
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    cmake --build build
+    echo "logos-lez-multisig-app built successfully!"
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/modules $out/qml
+
+    # Install app binary
+    if [ -f "build/bin/logos-lez-multisig-app" ]; then
+      cp build/bin/logos-lez-multisig-app "$out/bin/"
+    fi
+
+    # Copy core binaries from liblogos
+    if [ -f "${logosLiblogos}/bin/logoscore" ]; then
+      cp -L "${logosLiblogos}/bin/logoscore" "$out/bin/"
+    fi
+    if [ -f "${logosLiblogos}/bin/logos_host" ]; then
+      cp -L "${logosLiblogos}/bin/logos_host" "$out/bin/"
+    fi
+
+    # Copy shared libraries
+    if ls "${logosLiblogos}/lib/"liblogos_core.* >/dev/null 2>&1; then
+      cp -L "${logosLiblogos}/lib/"liblogos_core.* "$out/lib/" || true
+    fi
+    if ls "${logosSdk}/lib/"liblogos_sdk.* >/dev/null 2>&1; then
+      cp -L "${logosSdk}/lib/"liblogos_sdk.* "$out/lib/" || true
+    fi
+
+    # Copy lez-multisig-ffi library
+    if ls "${lezMultisigFfi}/lib/"liblez_multisig_ffi.* >/dev/null 2>&1; then
+      cp -L "${lezMultisigFfi}/lib/"liblez_multisig_ffi.* "$out/lib/" || true
+    fi
+
+    # Determine plugin extension
+    OS_EXT="so"
+    case "$(uname -s)" in
+      Darwin) OS_EXT="dylib";;
+    esac
+
+    # Copy module plugins
+    if [ -f "${logosCapabilityModule}/lib/capability_module_plugin.$OS_EXT" ]; then
+      cp -L "${logosCapabilityModule}/lib/capability_module_plugin.$OS_EXT" "$out/modules/"
+    fi
+    if [ -f "${lezMultisigModule}/lib/liblez_multisig_module.$OS_EXT" ]; then
+      cp -L "${lezMultisigModule}/lib/liblez_multisig_module.$OS_EXT" "$out/modules/"
+    fi
+
+    # Copy QML files for the app to find
+    cp ${src}/qml/*.qml "$out/qml/" 2>/dev/null || true
+
+    runHook postInstall
+  '';
+}

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -173,7 +173,7 @@ pkgs.stdenv.mkDerivation rec {
     fi
 
     # Copy QML files for the app to find
-    cp ${src}/qml/*.qml "$out/qml/" 2>/dev/null || true
+    cp -r ${src}/qml/* "$out/qml/" 2>/dev/null || true
 
     runHook postInstall
   '';

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,39 @@
+# Common build configuration shared across all packages
+{ pkgs, logosSdk, logosLiblogos }:
+
+{
+  pname = "logos-lez-multisig";
+  version = "0.1.0";
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.ninja
+    pkgs.pkg-config
+    pkgs.qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    pkgs.qt6.qtbase
+    pkgs.qt6.qtremoteobjects
+    pkgs.qt6.qtdeclarative
+    pkgs.zstd
+    pkgs.krb5
+    pkgs.abseil-cpp
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DLOGOS_CPP_SDK_ROOT=${logosSdk}"
+    "-DLOGOS_LIBLOGOS_ROOT=${logosLiblogos}"
+  ];
+
+  env = {
+    LOGOS_CPP_SDK_ROOT = "${logosSdk}";
+    LOGOS_LIBLOGOS_ROOT = "${logosLiblogos}";
+  };
+
+  meta = with pkgs.lib; {
+    description = "LEZ Multisig - Logos Core Qt6 plugin and standalone app";
+    platforms = platforms.unix;
+  };
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,57 @@
+# Builds the lez-multisig-module plugin .so
+{ pkgs, common, src, logosSdk, logosLiblogos, lezMultisigFfi, lezRegistryFfi }:
+
+let
+  llvmPkgs = pkgs.llvmPackages;
+
+  # Create a merged LOGOS_CORE_ROOT with headers from SDK and libs from liblogos
+  mergedLogosCore = pkgs.symlinkJoin {
+    name = "logos-core-merged";
+    paths = [ logosSdk logosLiblogos ];
+  };
+in
+pkgs.stdenv.mkDerivation {
+  pname = "${common.pname}-lib";
+  version = common.version;
+
+  inherit src;
+  inherit (common) meta;
+
+  nativeBuildInputs = common.nativeBuildInputs;
+
+  buildInputs = common.buildInputs ++ [
+    llvmPkgs.clang
+    llvmPkgs.libclang
+    lezMultisigFfi
+    lezRegistryFfi
+  ];
+
+  LIBCLANG_PATH = "${llvmPkgs.libclang.lib}/lib";
+  CLANG_PATH = "${llvmPkgs.clang}/bin/clang";
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DLOGOS_CORE_ROOT=${mergedLogosCore}"
+    "-DLEZ_MULTISIG_LIB=${lezMultisigFfi}/lib"
+    "-DLEZ_MULTISIG_INCLUDE=${lezMultisigFfi}/include"
+    "-DLEZ_REGISTRY_INCLUDE=${lezRegistryFfi}/include"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    found=""
+    for f in $(find . -name "liblez_multisig_module.so" -type f); do
+      cp "$f" $out/lib/
+      found=1
+    done
+    if [ -z "$found" ]; then
+      echo "Error: liblez_multisig_module.so not found"
+      find . -name "liblez_multisig*" -type f
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+}

--- a/nix/ui.nix
+++ b/nix/ui.nix
@@ -1,0 +1,58 @@
+# Builds the lez-multisig-ui IComponent plugin .so (for logos-app-poc "UI Modules" tab)
+{ pkgs, common, src, logosSdk, logosLiblogos, lezMultisigFfi, lezRegistryFfi }:
+
+let
+  llvmPkgs = pkgs.llvmPackages;
+
+  # Create a merged LOGOS_CORE_ROOT with headers from SDK and libs from liblogos
+  mergedLogosCore = pkgs.symlinkJoin {
+    name = "logos-core-merged";
+    paths = [ logosSdk logosLiblogos ];
+  };
+in
+pkgs.stdenv.mkDerivation {
+  pname = "${common.pname}-ui";
+  version = common.version;
+
+  inherit src;
+  inherit (common) meta;
+
+  nativeBuildInputs = common.nativeBuildInputs;
+
+  buildInputs = common.buildInputs ++ [
+    llvmPkgs.clang
+    llvmPkgs.libclang
+    lezMultisigFfi
+    lezRegistryFfi
+  ];
+
+  LIBCLANG_PATH = "${llvmPkgs.libclang.lib}/lib";
+  CLANG_PATH = "${llvmPkgs.clang}/bin/clang";
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DLOGOS_CORE_ROOT=${mergedLogosCore}"
+    "-DLEZ_MULTISIG_LIB=${lezMultisigFfi}/lib"
+    "-DLEZ_MULTISIG_INCLUDE=${lezMultisigFfi}/include"
+    "-DLEZ_REGISTRY_INCLUDE=${lezRegistryFfi}/include"
+    "-DBUILD_UI_PLUGIN=ON"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    found=""
+    for f in $(find . -name "liblez_multisig_ui.so" -type f); do
+      cp "$f" $out/lib/
+      found=1
+    done
+    if [ -z "$found" ]; then
+      echo "Error: liblez_multisig_ui.so not found"
+      find . -name "liblez_multisig*" -type f
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+}

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -206,6 +206,22 @@ Item {
                     }
                 }
 
+                Text { text: "Account / Signer (hex64) *"; color: Theme.palette.textSecondary; font.pixelSize: 12 }
+                Rectangle {
+                    Layout.fillWidth: true; height: 36; radius: Theme.spacing.tiny
+                    color: Theme.palette.backgroundSecondary
+                    border { color: accountField.activeFocus ? Theme.palette.primary : Theme.palette.borderSecondary; width: 1 }
+                    TextField {
+                        id: accountField
+                        anchors { fill: parent; leftMargin: 8; rightMargin: 8 }
+                        background: Item {}
+                        color: Theme.palette.text
+                        placeholderText: "signer account id (64 hex chars)"
+                        placeholderTextColor: Theme.palette.textTertiary
+                        font { pixelSize: 13; family: "monospace" }
+                    }
+                }
+
                 Text { text: "Wallet Path (optional)"; color: Theme.palette.textSecondary; font.pixelSize: 12 }
                 Rectangle {
                     Layout.fillWidth: true; height: 36; radius: Theme.spacing.tiny
@@ -277,6 +293,9 @@ Item {
                         }
                         if (walletPathField.text.length > 0) {
                             args["wallet_path"] = walletPathField.text.trim()
+                        }
+                        if (accountField.text.length > 0) {
+                            args["account"] = accountField.text.trim()
                         }
 
                         root.submitting = true

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -121,7 +121,7 @@ Item {
                     label: "Multisig Program ID"
                     placeholder: "64 hex chars (0x...)"
                     required: true
-                    TextField { id: programIdField; visible: false }
+                    TextField { id: programIdField_hidden; visible: false }
                 }
 
                 // Actual fields using property aliases trick — use direct TextFields

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -128,7 +128,7 @@ Item {
                         anchors { fill: parent; leftMargin: 8; rightMargin: 8 }
                         background: Item {}
                         color: Theme.palette.text
-                        text: "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"; placeholderText: "64 hex chars"
+                        text: "1e6b3b2014f1100e4426ea0a5e2f719366b50fa15292f4a5487fffc4a0de6b7c"; placeholderText: "64 hex chars"
                         placeholderTextColor: Theme.palette.textTertiary
                         font { pixelSize: 13; family: "monospace" }
                     }

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -53,7 +53,7 @@ Item {
             Button {
                 text: "✕ Cancel"
                 flat: true
-                onClicked: root.cancelled()
+                onClicked: { root.submitting = false; root.cancelled() }
                 contentItem: Text {
                     text: parent.text
                     color: Theme.palette.textSecondary

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import LezMultisig 1.0
 
 /**
  * CreateMultisigForm — form to create a new M-of-N multisig.

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -128,7 +128,7 @@ Item {
                         anchors { fill: parent; leftMargin: 8; rightMargin: 8 }
                         background: Item {}
                         color: Theme.palette.text
-                        placeholderText: "64 hex chars"
+                        text: "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"; placeholderText: "64 hex chars"
                         placeholderTextColor: Theme.palette.textTertiary
                         font { pixelSize: 13; family: "monospace" }
                     }

--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -116,13 +116,6 @@ Item {
                     }
                 }
 
-                FormField {
-                    id: programIdField_wrapper
-                    label: "Multisig Program ID"
-                    placeholder: "64 hex chars (0x...)"
-                    required: true
-                    TextField { id: programIdField_hidden; visible: false }
-                }
 
                 // Actual fields using property aliases trick — use direct TextFields
                 Text { text: "Multisig Program ID *"; color: Theme.palette.textSecondary; font.pixelSize: 12 }

--- a/qml/LezMultisig/Theme.qml
+++ b/qml/LezMultisig/Theme.qml
@@ -1,0 +1,33 @@
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    id: theme
+
+    readonly property QtObject palette: QtObject {
+        readonly property color background:          "#1a1a2e"
+        readonly property color backgroundSecondary: "#16213e"
+        readonly property color backgroundTertiary:  "#0f3460"
+        readonly property color borderSecondary:     "#2B303B"
+        readonly property color primary:             "#f5a623"
+        readonly property color primaryHover:        "#e0951e"
+        readonly property color primaryPressed:      "#cc8619"
+        readonly property color text:                "#FFFFFF"
+        readonly property color textSecondary:       "#A4A4A4"
+        readonly property color textTertiary:        "#707070"
+        readonly property color success:             "#4CAF50"
+        readonly property color error:               "#F44336"
+        readonly property color info:                "#2196F3"
+        readonly property color warning:             "#f5a623"
+    }
+
+    readonly property QtObject spacing: QtObject {
+        readonly property int tiny:   4
+        readonly property int small:  8
+        readonly property int medium: 12
+        readonly property int large:  16
+        readonly property int xlarge: 20
+        readonly property int radiusLarge:  8
+        readonly property int radiusXlarge: 16
+    }
+}

--- a/qml/LezMultisig/qmldir
+++ b/qml/LezMultisig/qmldir
@@ -1,1 +1,2 @@
+module LezMultisig
 singleton Theme 1.0 Theme.qml

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -6,14 +6,132 @@ import LezMultisig 1.0
 Item {
     id: root
 
+    // View stack: 0=list, 1=detail, 2=createMultisig, 3=propose
     property int currentView: 0
+
+    // Currently selected proposal (for detail view)
+    property int    selectedIndex:       0
+    property string selectedProposer:    ""
+    property string selectedTarget:      ""
+    property int    selectedApproved:    0
+    property int    selectedRejected:    0
+    property string selectedStatus:      ""
+    property string selectedPda:         ""
+    property int    selectedThreshold:   2
+
+    // Multisig config — populated from getState or user input
+    property string multisigCreateKey:     ""
+    property string multisigProgramId:     ""
+    property int    multisigThreshold:     0
+    property int    multisigMemberCount:   0
+
+    // Use the real model exposed from C++ via context property, fallback to demo
+    property bool hasRealModel: typeof lezMultisigModel !== "undefined" && lezMultisigModel !== null
+    property bool hasModule:    typeof lezMultisigModule !== "undefined" && lezMultisigModule !== null
 
     Rectangle {
         anchors.fill: parent
         color: Theme.palette.background
     }
 
+    // ── Helper: build common args JSON ───────────────────────────────────────
+    function commonArgs() {
+        var args = {}
+        if (multisigProgramId.length > 0)
+            args["multisig_program_id"] = multisigProgramId
+        if (multisigCreateKey.length > 0)
+            args["create_key"] = multisigCreateKey
+        return args
+    }
+
+    function proposalArgs(proposalIndex) {
+        var args = commonArgs()
+        args["proposal_index"] = proposalIndex
+        return JSON.stringify(args)
+    }
+
+    // ── Refresh proposals via real model ──────────────────────────────────────
+    function refreshProposals() {
+        if (hasRealModel && multisigCreateKey.length > 0 && multisigProgramId.length > 0) {
+            lezMultisigModel.setCreateKey(multisigCreateKey)
+            lezMultisigModel.setMultisigProgramId(multisigProgramId)
+            if (sequencerUrlField.text.length > 0)
+                lezMultisigModel.setSequencerUrl(sequencerUrlField.text)
+            lezMultisigModel.refresh()
+        }
+    }
+
+    // ── Fetch multisig state ─────────────────────────────────────────────────
+    function refreshState() {
+        if (!hasModule) return
+        var args = commonArgs()
+        var resultJson = lezMultisigModule.getState(JSON.stringify(args))
+        try {
+            var result = JSON.parse(resultJson)
+            if (result.success && result.state) {
+                multisigThreshold   = result.state.threshold   || 0
+                multisigMemberCount = result.state.member_count || 0
+            }
+        } catch(e) {
+            console.warn("getState parse error:", e)
+        }
+    }
+
+    // ── Signal connections to module ─────────────────────────────────────────
+    Connections {
+        target: hasModule ? lezMultisigModule : null
+        enabled: hasModule
+
+        function onActionCompleted(resultJson) {
+            detailView.actioning    = false
+            detailView.actionResult = "Action completed successfully"
+            refreshProposals()
+        }
+        function onActionFailed(error) {
+            detailView.actioning   = false
+            detailView.actionError = error
+        }
+        function onMultisigCreated(resultJson) {
+            createForm.submitting = false
+            try {
+                var r = JSON.parse(resultJson)
+                if (r.create_key) multisigCreateKey = r.create_key
+                createForm.submitResult = "Multisig created! TX: " + (r.tx_hash || "OK")
+            } catch(e) {
+                createForm.submitResult = "Multisig created!"
+            }
+            refreshState()
+            refreshProposals()
+        }
+        function onProposalCreated(resultJson) {
+            proposeForm.submitting = false
+            try {
+                var r = JSON.parse(resultJson)
+                proposeForm.submitResult = "Proposal #" + (r.proposal_index || "?") + " created!"
+            } catch(e) {
+                proposeForm.submitResult = "Proposal created!"
+            }
+            refreshProposals()
+        }
+    }
+
+    Connections {
+        target: hasRealModel ? lezMultisigModel : null
+        enabled: hasRealModel
+
+        function onRefreshed() {
+            // Update proposal count display
+        }
+        function onErrorChanged() {
+            if (lezMultisigModel.error.length > 0)
+                console.warn("Model error:", lezMultisigModel.error)
+        }
+    }
+
+    // ── View: Proposal List ──────────────────────────────────────────────────
     ColumnLayout {
+        id: listView
+        visible: root.currentView === 0
         anchors.fill: parent
         anchors.margins: 24
         spacing: 20
@@ -23,7 +141,6 @@ Item {
             Layout.fillWidth: true
             spacing: 12
 
-            // Lock icon as styled text instead of emoji
             Rectangle {
                 width: 36; height: 36; radius: 8
                 color: Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.15)
@@ -43,6 +160,48 @@ Item {
 
             Item { Layout.fillWidth: true }
 
+            // Refresh button
+            Rectangle {
+                width: refreshBtn.width + 24; height: 36; radius: 8
+                color: refreshArea.containsMouse ? Theme.palette.backgroundTertiary : Theme.palette.backgroundSecondary
+                border { color: Theme.palette.borderSecondary; width: 1 }
+                Text {
+                    id: refreshBtn; anchors.centerIn: parent
+                    text: hasRealModel && lezMultisigModel.loading ? "⏳" : "↻ Refresh"
+                    color: Theme.palette.textSecondary; font { pixelSize: 14 }
+                }
+                MouseArea {
+                    id: refreshArea
+                    anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onClicked: { refreshState(); refreshProposals() }
+                }
+            }
+
+            // New Proposal button
+            Rectangle {
+                width: proposeBtn.width + 24; height: 36; radius: 8
+                color: Theme.palette.backgroundTertiary
+                border { color: Theme.palette.primary; width: 1 }
+                Text {
+                    id: proposeBtn; anchors.centerIn: parent
+                    text: "+ Proposal"; color: Theme.palette.primary; font { pixelSize: 14; bold: true }
+                }
+                MouseArea {
+                    anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onContainsMouseChanged: parent.color = containsMouse ? Qt.lighter(Theme.palette.backgroundTertiary, 1.2) : Theme.palette.backgroundTertiary
+                    onClicked: {
+                        proposeForm.reset()
+                        proposeForm.createKey         = root.multisigCreateKey
+                        proposeForm.multisigProgramId = root.multisigProgramId
+                        proposeForm.sequencerUrl      = sequencerUrlField.text
+                        root.currentView = 3
+                    }
+                }
+            }
+
+            // New Multisig button
             Rectangle {
                 width: createBtn.width + 24; height: 36; radius: 8
                 color: Theme.palette.primary
@@ -54,6 +213,73 @@ Item {
                     anchors.fill: parent; cursorShape: Qt.PointingHandCursor
                     hoverEnabled: true
                     onContainsMouseChanged: parent.color = containsMouse ? Theme.palette.primaryHover : Theme.palette.primary
+                    onClicked: { createForm.reset(); root.currentView = 2 }
+                }
+            }
+        }
+
+        // Config bar: sequencer URL + multisig keys
+        Rectangle {
+            Layout.fillWidth: true; height: configCol.implicitHeight + 16; radius: 8
+            color: Theme.palette.backgroundSecondary
+            border { color: Theme.palette.borderSecondary; width: 1 }
+
+            ColumnLayout {
+                id: configCol
+                anchors { left: parent.left; right: parent.right; top: parent.top; margins: 12 }
+                spacing: 6
+
+                RowLayout {
+                    Layout.fillWidth: true; spacing: 8
+                    Text { text: "Sequencer:"; color: Theme.palette.textTertiary; font.pixelSize: 12 }
+                    Rectangle {
+                        Layout.fillWidth: true; height: 28; radius: 4
+                        color: Theme.palette.backgroundTertiary
+                        border { color: sequencerUrlField.activeFocus ? Theme.palette.primary : Theme.palette.borderSecondary; width: 1 }
+                        TextField {
+                            id: sequencerUrlField
+                            anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
+                            background: Item {}
+                            color: Theme.palette.text
+                            text: hasRealModel ? lezMultisigModel.sequencerUrl() : "http://localhost:9000"
+                            font { pixelSize: 12; family: "monospace" }
+                        }
+                    }
+                }
+                RowLayout {
+                    Layout.fillWidth: true; spacing: 8
+                    Text { text: "Program ID:"; color: Theme.palette.textTertiary; font.pixelSize: 12 }
+                    Rectangle {
+                        Layout.fillWidth: true; height: 28; radius: 4
+                        color: Theme.palette.backgroundTertiary
+                        border { color: progIdField.activeFocus ? Theme.palette.primary : Theme.palette.borderSecondary; width: 1 }
+                        TextField {
+                            id: progIdField
+                            anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
+                            background: Item {}
+                            color: Theme.palette.text
+                            placeholderText: "multisig program id (hex64)"
+                            placeholderTextColor: Theme.palette.textTertiary
+                            font { pixelSize: 12; family: "monospace" }
+                            onTextChanged: root.multisigProgramId = text.trim()
+                        }
+                    }
+                    Text { text: "Create Key:"; color: Theme.palette.textTertiary; font.pixelSize: 12 }
+                    Rectangle {
+                        Layout.fillWidth: true; height: 28; radius: 4
+                        color: Theme.palette.backgroundTertiary
+                        border { color: createKeyField.activeFocus ? Theme.palette.primary : Theme.palette.borderSecondary; width: 1 }
+                        TextField {
+                            id: createKeyField
+                            anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
+                            background: Item {}
+                            color: Theme.palette.text
+                            placeholderText: "create key (hex64)"
+                            placeholderTextColor: Theme.palette.textTertiary
+                            font { pixelSize: 12; family: "monospace" }
+                            onTextChanged: root.multisigCreateKey = text.trim()
+                        }
+                    }
                 }
             }
         }
@@ -65,44 +291,164 @@ Item {
             border { color: Theme.palette.borderSecondary; width: 1 }
             RowLayout {
                 anchors.fill: parent; anchors.leftMargin: 16; anchors.rightMargin: 16
-                Text { text: "Threshold: 2 of 3"; color: Theme.palette.textSecondary; font.pixelSize: 13 }
+                Text {
+                    text: "Threshold: " + (root.multisigThreshold > 0 ? root.multisigThreshold + " of " + root.multisigMemberCount : "—")
+                    color: Theme.palette.textSecondary; font.pixelSize: 13
+                }
                 Item { Layout.fillWidth: true }
-                Text { text: "Members: 3"; color: Theme.palette.textSecondary; font.pixelSize: 13 }
+                Text {
+                    text: "Members: " + (root.multisigMemberCount > 0 ? root.multisigMemberCount : "—")
+                    color: Theme.palette.textSecondary; font.pixelSize: 13
+                }
                 Item { width: 20 }
-                Text { text: "Proposals: 3"; color: Theme.palette.success; font { pixelSize: 13; bold: true } }
+                Text {
+                    text: "Proposals: " + (hasRealModel ? lezMultisigModel.count : demoModel.count)
+                    color: Theme.palette.success; font { pixelSize: 13; bold: true }
+                }
+                Item { width: 12 }
+                // Loading indicator
+                Text {
+                    visible: hasRealModel && lezMultisigModel.loading
+                    text: "⏳ Loading…"
+                    color: Theme.palette.warning; font.pixelSize: 12
+                }
+                // Error indicator
+                Text {
+                    visible: hasRealModel && lezMultisigModel.error.length > 0
+                    text: "⚠ " + (hasRealModel ? lezMultisigModel.error : "")
+                    color: Theme.palette.error; font.pixelSize: 11
+                    elide: Text.ElideRight
+                    Layout.maximumWidth: 300
+                }
             }
         }
 
         Rectangle { Layout.fillWidth: true; height: 1; color: Theme.palette.borderSecondary }
 
-        // Proposal list
-        Repeater {
-            model: proposalModel
-            delegate: ProposalCard {
-                Layout.fillWidth: true
-                proposalIndex: model.index
-                proposer: model.proposer
-                targetProgramId: model.targetProgram
-                approvedCount: model.approved
-                rejectedCount: model.rejected
-                status: model.status
-                threshold: 2
+        // Proposal list — use real model if available, else demo
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            ColumnLayout {
+                width: parent.width
+                spacing: 8
+
+                Repeater {
+                    model: hasRealModel ? lezMultisigModel : demoModel
+                    delegate: ProposalCard {
+                        Layout.fillWidth: true
+                        proposalIndex:     model.proposalIndex !== undefined ? model.proposalIndex : model.index
+                        proposer:          model.proposer || ""
+                        targetProgramId:   model.targetProgramId || model.targetProgram || ""
+                        approvedCount:     model.approvedCount !== undefined ? model.approvedCount : (model.approved || 0)
+                        rejectedCount:     model.rejectedCount !== undefined ? model.rejectedCount : (model.rejected || 0)
+                        status:            model.status || "Active"
+                        proposalPda:       model.proposalPda || ""
+                        threshold:         root.multisigThreshold > 0 ? root.multisigThreshold : 2
+
+                        onClicked: {
+                            root.selectedIndex    = proposalIndex
+                            root.selectedProposer = proposer
+                            root.selectedTarget   = targetProgramId
+                            root.selectedApproved = approvedCount
+                            root.selectedRejected = rejectedCount
+                            root.selectedStatus   = status
+                            root.selectedPda      = proposalPda
+                            root.selectedThreshold = threshold
+                            detailView.actionError  = ""
+                            detailView.actionResult = ""
+                            detailView.actioning    = false
+                            root.currentView = 1
+                        }
+                    }
+                }
+
+                // Empty state
+                Text {
+                    visible: (hasRealModel ? lezMultisigModel.count : demoModel.count) === 0
+                    text: hasRealModel ? "No proposals yet. Create a multisig or refresh." : "Configure sequencer and keys above, then click Refresh."
+                    color: Theme.palette.textTertiary
+                    font.pixelSize: 14
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.topMargin: 40
+                }
             }
         }
 
-        Item { Layout.fillHeight: true }
-
         Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Powered by Logos \u00b7 LEZ Multisig v0.1.0"
+            text: "Powered by Logos · LEZ Multisig" + (hasModule ? " v" + lezMultisigModule.version() : " v0.1.0")
             color: Theme.palette.textTertiary; font.pixelSize: 11
         }
     }
 
+    // ── Demo fallback model ──────────────────────────────────────────────────
     ListModel {
-        id: proposalModel
-        ListElement { proposer: "jimmy-claw"; targetProgram: "lez-registry: register(...)"; approved: 2; rejected: 0; status: "Approved" }
-        ListElement { proposer: "logos-team"; targetProgram: "token-factory: mint(1000)"; approved: 1; rejected: 0; status: "Active" }
-        ListElement { proposer: "defi-dev"; targetProgram: "amm-swap: addLiquidity(...)"; approved: 0; rejected: 2; status: "Rejected" }
+        id: demoModel
+        ListElement { proposalIndex: 0; proposer: "jimmy-claw"; targetProgram: "lez-registry: register(...)"; approved: 2; rejected: 0; status: "Approved" }
+        ListElement { proposalIndex: 1; proposer: "logos-team"; targetProgram: "token-factory: mint(1000)"; approved: 1; rejected: 0; status: "Active" }
+        ListElement { proposalIndex: 2; proposer: "defi-dev"; targetProgram: "amm-swap: addLiquidity(...)"; approved: 0; rejected: 2; status: "Rejected" }
+    }
+
+    // ── View: Proposal Detail ────────────────────────────────────────────────
+    ProposalDetail {
+        id: detailView
+        visible: root.currentView === 1
+        anchors.fill: parent
+
+        proposalIndex:   root.selectedIndex
+        proposer:        root.selectedProposer
+        targetProgramId: root.selectedTarget
+        approvedCount:   root.selectedApproved
+        rejectedCount:   root.selectedRejected
+        status:          root.selectedStatus
+        proposalPda:     root.selectedPda
+        threshold:       root.selectedThreshold
+
+        onBackRequested: root.currentView = 0
+
+        onApproveRequested: {
+            if (!hasModule) { actionError = "Module not loaded"; return }
+            actioning = true; actionError = ""; actionResult = ""
+            lezMultisigModule.approveAsync(root.proposalArgs(root.selectedIndex))
+        }
+        onRejectRequested: {
+            if (!hasModule) { actionError = "Module not loaded"; return }
+            actioning = true; actionError = ""; actionResult = ""
+            lezMultisigModule.rejectAsync(root.proposalArgs(root.selectedIndex))
+        }
+        onExecuteRequested: {
+            if (!hasModule) { actionError = "Module not loaded"; return }
+            actioning = true; actionError = ""; actionResult = ""
+            lezMultisigModule.executeAsync(root.proposalArgs(root.selectedIndex))
+        }
+    }
+
+    // ── View: Create Multisig ────────────────────────────────────────────────
+    CreateMultisigForm {
+        id: createForm
+        visible: root.currentView === 2
+        anchors.fill: parent
+
+        onCancelled: root.currentView = 0
+        onSubmitRequested: function(argsJson) {
+            if (!hasModule) { submitError = "Module not loaded"; submitting = false; return }
+            lezMultisigModule.createMultisigAsync(argsJson)
+        }
+    }
+
+    // ── View: Propose ────────────────────────────────────────────────────────
+    ProposeForm {
+        id: proposeForm
+        visible: root.currentView === 3
+        anchors.fill: parent
+
+        onCancelled: root.currentView = 0
+        onSubmitRequested: function(argsJson) {
+            if (!hasModule) { submitError = "Module not loaded"; submitting = false; return }
+            lezMultisigModule.proposeAsync(argsJson)
+        }
     }
 }

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -432,7 +432,7 @@ Item {
         visible: root.currentView === 2
         anchors.fill: parent
 
-        onCancelled: root.currentView = 0
+        onCancelled: { root.currentView = 0 }
         onSubmitRequested: function(argsJson) {
             if (!hasModule) { submitError = "Module not loaded"; submitting = false; return }
             lezMultisigModule.createMultisigAsync(argsJson)
@@ -445,7 +445,7 @@ Item {
         visible: root.currentView === 3
         anchors.fill: parent
 
-        onCancelled: root.currentView = 0
+        onCancelled: { root.currentView = 0 }
         onSubmitRequested: function(argsJson) {
             if (!hasModule) { submitError = "Module not loaded"; submitting = false; return }
             lezMultisigModule.proposeAsync(argsJson)

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -61,6 +61,25 @@ Item {
         }
     }
 
+
+    // ── Load known multisigs from persistence ────────────────────────────────
+    function loadKnownMultisigs() {
+        if (!hasModule) return
+        knownMultisigsModel.clear()
+        try {
+            var arr = JSON.parse(lezMultisigModule.loadMultisigs())
+            for (var i = 0; i < arr.length; i++) {
+                knownMultisigsModel.append({
+                    "displayName": arr[i].name + " (" + arr[i].create_key.substring(0, 8) + "...)",
+                    "programId": arr[i].program_id,
+                    "createKey": arr[i].create_key
+                })
+            }
+        } catch(e) {
+            console.warn("Failed to load known multisigs:", e)
+        }
+    }
+
     // ── Fetch multisig state ─────────────────────────────────────────────────
     function refreshState() {
         if (!hasModule) return
@@ -74,6 +93,18 @@ Item {
             }
         } catch(e) {
             console.warn("getState parse error:", e)
+        }
+    }
+
+    // ── Auto-navigate timer after multisig creation ──────────────────────────
+    Timer {
+        id: autoNavigateTimer
+        interval: 1500
+        repeat: false
+        onTriggered: {
+            root.currentView = 0
+            refreshState()
+            refreshProposals()
         }
     }
 
@@ -104,8 +135,12 @@ Item {
             } catch(e) {
                 createForm.submitResult = "Multisig created!"
             }
-            refreshState()
-            refreshProposals()
+            // Save to known multisigs
+            if (hasModule && multisigCreateKey.length > 0) {
+                lezMultisigModule.saveMultisig("Multisig " + multisigCreateKey.substring(0, 8), multisigProgramId, multisigCreateKey)
+                loadKnownMultisigs()
+            }
+            autoNavigateTimer.start()
         }
         function onProposalCreated(resultJson) {
             proposeForm.submitting = false
@@ -233,6 +268,47 @@ Item {
                 anchors { left: parent.left; right: parent.right; top: parent.top; margins: 12 }
                 spacing: 6
 
+                // Known multisigs selector
+                RowLayout {
+                    Layout.fillWidth: true; spacing: 8
+                    Text { text: "Known:"; color: Theme.palette.textTertiary; font.pixelSize: 12 }
+                    Rectangle {
+                        Layout.fillWidth: true; height: 28; radius: 4
+                        color: Theme.palette.backgroundTertiary
+                        border { color: Theme.palette.borderSecondary; width: 1 }
+                        ComboBox {
+                            id: knownMultisigSelector
+                            anchors.fill: parent
+                            model: ListModel { id: knownMultisigsModel }
+                            textRole: "displayName"
+                            font.pixelSize: 12
+
+                            background: Rectangle {
+                                color: "transparent"
+                            }
+                            contentItem: Text {
+                                text: knownMultisigSelector.displayText || "Select a multisig..."
+                                color: Theme.palette.text
+                                font { pixelSize: 12; family: "monospace" }
+                                verticalAlignment: Text.AlignVCenter
+                                leftPadding: 6
+                                elide: Text.ElideRight
+                            }
+
+                            onActivated: function(index) {
+                                if (index < 0) return
+                                var item = knownMultisigsModel.get(index)
+                                if (!item) return
+                                progIdField.text = item.programId
+                                createKeyField.text = item.createKey
+                                root.multisigProgramId = item.programId
+                                root.multisigCreateKey = item.createKey
+                                refreshState()
+                                refreshProposals()
+                            }
+                        }
+                    }
+                }
                 RowLayout {
                     Layout.fillWidth: true; spacing: 8
                     Text { text: "Sequencer:"; color: Theme.palette.textTertiary; font.pixelSize: 12 }
@@ -441,6 +517,11 @@ Item {
             if (!hasModule) { submitError = "Module not loaded"; submitting = false; return }
             lezMultisigModule.createMultisigAsync(argsJson)
         }
+    }
+
+    // ── Load known multisigs on startup ─────────────────────────────────────
+    Component.onCompleted: {
+        loadKnownMultisigs()
     }
 
     // ── View: Propose ────────────────────────────────────────────────────────

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import LezMultisig 1.0
 
 Item {
     id: root

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -90,6 +90,10 @@ Item {
         function onActionFailed(error) {
             detailView.actioning   = false
             detailView.actionError = error
+            createForm.submitting  = false
+            createForm.submitError = error
+            proposeForm.submitting = false
+            proposeForm.submitError = error
         }
         function onMultisigCreated(resultJson) {
             createForm.submitting = false

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -21,7 +21,7 @@ Item {
 
     // Multisig config — populated from getState or user input
     property string multisigCreateKey:     ""
-    property string multisigProgramId:     "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"
+    property string multisigProgramId:     "1e6b3b2014f1100e4426ea0a5e2f719366b50fa15292f4a5487fffc4a0de6b7c"
     property int    multisigThreshold:     0
     property int    multisigMemberCount:   0
 
@@ -262,7 +262,7 @@ Item {
                             anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
                             background: Item {}
                             color: Theme.palette.text
-                            text: "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"; placeholderText: "multisig program id (hex64)"
+                            text: "1e6b3b2014f1100e4426ea0a5e2f719366b50fa15292f4a5487fffc4a0de6b7c"; placeholderText: "multisig program id (hex64)"
                             placeholderTextColor: Theme.palette.textTertiary
                             font { pixelSize: 12; family: "monospace" }
                             onTextChanged: root.multisigProgramId = text.trim()

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -21,7 +21,7 @@ Item {
 
     // Multisig config — populated from getState or user input
     property string multisigCreateKey:     ""
-    property string multisigProgramId:     ""
+    property string multisigProgramId:     "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"
     property int    multisigThreshold:     0
     property int    multisigMemberCount:   0
 
@@ -241,7 +241,7 @@ Item {
                             anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
                             background: Item {}
                             color: Theme.palette.text
-                            text: hasRealModel ? lezMultisigModel.sequencerUrl() : "http://localhost:9000"
+                            text: hasRealModel ? lezMultisigModel.sequencerUrl() : "http://localhost:3040"
                             font { pixelSize: 12; family: "monospace" }
                         }
                     }
@@ -258,7 +258,7 @@ Item {
                             anchors { fill: parent; leftMargin: 6; rightMargin: 6 }
                             background: Item {}
                             color: Theme.palette.text
-                            placeholderText: "multisig program id (hex64)"
+                            text: "7f92d57b20a63264d90119c6322f7d8058ecf2b14f462d29d1ae6cf42e684006"; placeholderText: "multisig program id (hex64)"
                             placeholderTextColor: Theme.palette.textTertiary
                             font { pixelSize: 12; family: "monospace" }
                             onTextChanged: root.multisigProgramId = text.trim()

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -379,7 +379,7 @@ Item {
 
         Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Powered by Logos · LEZ Multisig" + (hasModule ? " v" + lezMultisigModule.version() : " v0.1.0")
+            text: "Powered by Logos · LEZ Multisig" + (hasModule && typeof lezMultisigModule.version === "function" ? " v" + lezMultisigModule.version() : " v0.1.0")
             color: Theme.palette.textTertiary; font.pixelSize: 11
         }
     }

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -5,51 +5,74 @@ import QtQuick.Layouts 1.15
 Item {
     id: root
 
-    property int currentView: 0  // 0=proposals, 1=detail, 2=create, 3=propose
+    property int currentView: 0
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.palette.background
+    }
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 20
-        spacing: 16
+        anchors.margins: 24
+        spacing: 20
 
         // Header
         RowLayout {
             Layout.fillWidth: true
             spacing: 12
 
+            // Lock icon as styled text instead of emoji
+            Rectangle {
+                width: 36; height: 36; radius: 8
+                color: Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.15)
+                border { color: Theme.palette.primary; width: 1 }
+                Text {
+                    anchors.centerIn: parent
+                    text: "\uD83D\uDD10"
+                    font.pixelSize: 18
+                }
+            }
+
             Text {
-                text: "🔐 LEZ Multisig"
-                font.pixelSize: 24
-                font.bold: true
-                color: "#ffffff"
+                text: "LEZ Multisig"
+                font { pixelSize: 24; bold: true }
+                color: Theme.palette.text
             }
 
             Item { Layout.fillWidth: true }
 
             Rectangle {
-                width: createBtn.width + 20; height: 36; radius: 8
-                color: "#FF8800"
+                width: createBtn.width + 24; height: 36; radius: 8
+                color: Theme.palette.primary
                 Text {
                     id: createBtn; anchors.centerIn: parent
-                    text: "+ New Multisig"; color: "#ffffff"; font.pixelSize: 14; font.bold: true
+                    text: "+ New Multisig"; color: "#ffffff"; font { pixelSize: 14; bold: true }
+                }
+                MouseArea {
+                    anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onContainsMouseChanged: parent.color = containsMouse ? Theme.palette.primaryHover : Theme.palette.primary
                 }
             }
         }
 
         // Info bar
         Rectangle {
-            Layout.fillWidth: true; height: 40; radius: 8; color: "#262626"
+            Layout.fillWidth: true; height: 44; radius: 8
+            color: Theme.palette.backgroundSecondary
+            border { color: Theme.palette.borderSecondary; width: 1 }
             RowLayout {
                 anchors.fill: parent; anchors.leftMargin: 16; anchors.rightMargin: 16
-                Text { text: "Threshold: 2 of 3"; color: "#A4A4A4"; font.pixelSize: 13 }
+                Text { text: "Threshold: 2 of 3"; color: Theme.palette.textSecondary; font.pixelSize: 13 }
                 Item { Layout.fillWidth: true }
-                Text { text: "Members: 3"; color: "#A4A4A4"; font.pixelSize: 13 }
+                Text { text: "Members: 3"; color: Theme.palette.textSecondary; font.pixelSize: 13 }
                 Item { width: 20 }
-                Text { text: "Proposals: 3"; color: "#49F563"; font.pixelSize: 13 }
+                Text { text: "Proposals: 3"; color: Theme.palette.success; font { pixelSize: 13; bold: true } }
             }
         }
 
-        Rectangle { Layout.fillWidth: true; height: 1; color: "#2B303B" }
+        Rectangle { Layout.fillWidth: true; height: 1; color: Theme.palette.borderSecondary }
 
         // Proposal list
         Repeater {
@@ -70,8 +93,8 @@ Item {
 
         Text {
             Layout.alignment: Qt.AlignHCenter
-            text: "Powered by Logos · LEZ Multisig v0.1.0"
-            color: "#555555"; font.pixelSize: 11
+            text: "Powered by Logos \u00b7 LEZ Multisig v0.1.0"
+            color: Theme.palette.textTertiary; font.pixelSize: 11
         }
     }
 

--- a/qml/ProposalCard.qml
+++ b/qml/ProposalCard.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import LezMultisig 1.0
 
 /**
  * ProposalCard — delegate component for a single multisig proposal.

--- a/qml/ProposalCard.qml
+++ b/qml/ProposalCard.qml
@@ -4,12 +4,10 @@ import QtQuick.Layouts 1.15
 
 /**
  * ProposalCard — delegate component for a single multisig proposal.
- * Shows index, status badge, approval counts, and target program snippet.
  */
 Rectangle {
     id: root
 
-    // ── Data ─────────────────────────────────────────────────────────────────
     property int    proposalIndex:      0
     property string proposer:           ""
     property string targetProgramId:    ""
@@ -19,13 +17,12 @@ Rectangle {
     property string proposalPda:        ""
     property int    threshold:          0
 
-    // ── Signals ───────────────────────────────────────────────────────────────
     signal clicked()
 
-    // ── Status color helper ────────────────────────────────────────────────────
     function statusColor(s) {
         switch(s) {
             case "Active":    return Theme.palette.warning;
+            case "Approved":  return Theme.palette.success;
             case "Executed":  return Theme.palette.info;
             case "Rejected":  return Theme.palette.error;
             case "Cancelled": return Theme.palette.textTertiary;
@@ -33,10 +30,9 @@ Rectangle {
         }
     }
 
-    // ── Layout ────────────────────────────────────────────────────────────────
-    height:  cardColumn.implicitHeight + 24
+    height:  cardColumn.implicitHeight + 28
     radius:  Theme.spacing.radiusLarge
-    color:   mouseArea.containsMouse ? Theme.palette.backgroundSecondary : Theme.palette.backgroundTertiary
+    color:   mouseArea.containsMouse ? Qt.lighter(Theme.palette.backgroundTertiary, 1.15) : Theme.palette.backgroundTertiary
 
     border {
         color: mouseArea.containsMouse ? Theme.palette.primary : Theme.palette.borderSecondary
@@ -60,11 +56,11 @@ Rectangle {
             left:   parent.left
             right:  parent.right
             top:    parent.top
-            margins: Theme.spacing.medium
+            margins: Theme.spacing.large
         }
-        spacing: Theme.spacing.tiny
+        spacing: Theme.spacing.small
 
-        // Index + Status row
+        // Row 1: Index + Status badge (left) ... Vote counts (right)
         RowLayout {
             Layout.fillWidth: true
             spacing: Theme.spacing.small
@@ -72,14 +68,14 @@ Rectangle {
             Text {
                 text: "#" + root.proposalIndex
                 color: Theme.palette.text
-                font { pixelSize: 15; bold: true; family: "monospace" }
+                font { pixelSize: 16; bold: true; family: "monospace" }
             }
 
             // Status badge
             Rectangle {
-                width:  statusLabel.implicitWidth + Theme.spacing.medium
-                height: 20
-                radius: 10
+                width:  statusLabel.implicitWidth + 16
+                height: 22
+                radius: 11
                 color: Qt.rgba(root.statusColor(root.status).r,
                                root.statusColor(root.status).g,
                                root.statusColor(root.status).b, 0.15)
@@ -90,44 +86,43 @@ Rectangle {
                     anchors.centerIn: parent
                     text: root.status
                     color: root.statusColor(root.status)
-                    font.pixelSize: 10
+                    font { pixelSize: 11; bold: true }
                 }
             }
 
             Item { Layout.fillWidth: true }
 
-            // Approval count
+            // Vote counts
             Text {
-                text: "✓ " + root.approvedCount + (root.threshold > 0 ? "/" + root.threshold : "")
+                text: "\u2713 " + root.approvedCount + (root.threshold > 0 ? "/" + root.threshold : "")
                 color: Theme.palette.success
-                font.pixelSize: 12
+                font { pixelSize: 13; bold: true }
             }
             Text {
-                text: "✗ " + root.rejectedCount
+                text: "\u2717 " + root.rejectedCount
                 color: Theme.palette.error
-                font.pixelSize: 12
+                font { pixelSize: 13; bold: true }
                 visible: root.rejectedCount > 0
             }
         }
 
-        // Target program
+        // Row 2: Target program — wider, elide in middle
         Text {
+            Layout.fillWidth: true
             visible: root.targetProgramId.length > 0
-            text: "→ " + (root.targetProgramId.length > 20
-                          ? root.targetProgramId.substring(0, 10) + "…" + root.targetProgramId.slice(-8)
-                          : root.targetProgramId)
+            text: "\u2192 " + root.targetProgramId
             color: Theme.palette.textSecondary
-            font { pixelSize: 11; family: "monospace" }
+            font { pixelSize: 12; family: "monospace" }
+            elide: Text.ElideMiddle
+            maximumLineCount: 1
         }
 
-        // Proposer
+        // Row 3: Proposer — subtle
         Text {
             visible: root.proposer.length > 0
-            text: "by " + (root.proposer.length > 20
-                          ? root.proposer.substring(0, 8) + "…" + root.proposer.slice(-6)
-                          : root.proposer)
+            text: "by " + root.proposer
             color: Theme.palette.textTertiary
-            font.pixelSize: 11
+            font { pixelSize: 10; italic: true }
         }
     }
 }

--- a/qml/ProposalDetail.qml
+++ b/qml/ProposalDetail.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import LezMultisig 1.0
 
 /**
  * ProposalDetail — full detail view for a multisig proposal.

--- a/qml/ProposeForm.qml
+++ b/qml/ProposeForm.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import LezMultisig 1.0
 
 /**
  * ProposeForm — form to create a new proposal in a multisig.

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -5,20 +5,20 @@ QtObject {
     id: theme
 
     readonly property QtObject palette: QtObject {
-        readonly property color background:          "#171717"
-        readonly property color backgroundSecondary: "#262626"
-        readonly property color backgroundTertiary:  "#1C1C1C"
+        readonly property color background:          "#1a1a2e"
+        readonly property color backgroundSecondary: "#16213e"
+        readonly property color backgroundTertiary:  "#0f3460"
         readonly property color borderSecondary:     "#2B303B"
-        readonly property color primary:             "#FF8800"
-        readonly property color primaryHover:        "#E07A00"
-        readonly property color primaryPressed:      "#CC6F00"
+        readonly property color primary:             "#f5a623"
+        readonly property color primaryHover:        "#e0951e"
+        readonly property color primaryPressed:      "#cc8619"
         readonly property color text:                "#FFFFFF"
         readonly property color textSecondary:       "#A4A4A4"
-        readonly property color textTertiary:        "#969696"
+        readonly property color textTertiary:        "#707070"
         readonly property color success:             "#4CAF50"
         readonly property color error:               "#F44336"
         readonly property color info:                "#2196F3"
-        readonly property color warning:             "#FF8800"
+        readonly property color warning:             "#f5a623"
     }
 
     readonly property QtObject spacing: QtObject {

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -1,11 +1,11 @@
 <RCC>
     <qresource prefix="/">
-        <file>qml/LezMultisigView.qml</file>
-        <file>qml/CreateMultisigForm.qml</file>
-        <file>qml/ProposeForm.qml</file>
-        <file>qml/ProposalCard.qml</file>
-        <file>qml/ProposalDetail.qml</file>
-        <file>qml/Theme.qml</file>
-        <file>qml/qmldir</file>
+        <file>LezMultisigView.qml</file>
+        <file>CreateMultisigForm.qml</file>
+        <file>ProposeForm.qml</file>
+        <file>ProposalCard.qml</file>
+        <file>ProposalDetail.qml</file>
+        <file>Theme.qml</file>
+        <file>qmldir</file>
     </qresource>
 </RCC>

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/">
+    <qresource prefix="/lez-multisig">
         <file>LezMultisigView.qml</file>
         <file>CreateMultisigForm.qml</file>
         <file>ProposeForm.qml</file>

--- a/qml/qml.qrc
+++ b/qml/qml.qrc
@@ -7,5 +7,7 @@
         <file>ProposalDetail.qml</file>
         <file>Theme.qml</file>
         <file>qmldir</file>
+        <file>LezMultisig/Theme.qml</file>
+        <file>LezMultisig/qmldir</file>
     </qresource>
 </RCC>

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -1,1 +1,2 @@
+module LezMultisig
 singleton Theme 1.0 Theme.qml

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/yvdl5s3lp4q6b56zmg7cmhrzmdzic048-logos-lez-multisig-lib-0.1.0

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/yvdl5s3lp4q6b56zmg7cmhrzmdzic048-logos-lez-multisig-lib-0.1.0

--- a/src/MultisigUIComponent.cpp
+++ b/src/MultisigUIComponent.cpp
@@ -1,0 +1,34 @@
+#include "MultisigUIComponent.h"
+#include "lez_multisig_module.h"
+#include "proposal_list_model.h"
+
+#include <QQuickWidget>
+#include <QQmlContext>
+
+QWidget* MultisigUIComponent::createWidget(LogosAPI* logosAPI) {
+    auto* quickWidget = new QQuickWidget();
+    quickWidget->setMinimumSize(400, 300);
+    quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+
+    auto* backend = new LezMultisigModule();
+    backend->setParent(quickWidget);
+
+    if (logosAPI) {
+        backend->initLogos(logosAPI);
+    }
+
+    quickWidget->rootContext()->setContextProperty("lezMultisigModule", backend);
+
+    ProposalListModel* model = backend->proposalModel();
+    if (model) {
+        quickWidget->rootContext()->setContextProperty("lezMultisigModel", model);
+    }
+
+    quickWidget->setSource(QUrl("qrc:/lez-multisig/LezMultisigView.qml"));
+
+    return quickWidget;
+}
+
+void MultisigUIComponent::destroyWidget(QWidget* widget) {
+    delete widget;
+}

--- a/src/MultisigUIComponent.h
+++ b/src/MultisigUIComponent.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <IComponent.h>
+#include <QObject>
+
+class MultisigUIComponent : public QObject, public IComponent {
+    Q_OBJECT
+    Q_INTERFACES(IComponent)
+    Q_PLUGIN_METADATA(IID IComponent_iid FILE LEZ_MULTISIG_UI_METADATA_FILE)
+
+public:
+    QWidget* createWidget(LogosAPI* logosAPI = nullptr) override;
+    void destroyWidget(QWidget* widget) override;
+};

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -9,6 +9,8 @@
 #include "registry_bridge.h"
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QFile>
+#include <QDir>
 #include <QByteArray>
 #include <QtConcurrent/QtConcurrent>
 
@@ -68,6 +70,14 @@ LezMultisigModule::LezMultisigModule()
         if (!root.value(QLatin1String("success")).toBool()) {
             emit actionFailed(root.value(QLatin1String("error")).toString(QStringLiteral("Unknown error")));
             return;
+        }
+        // Auto-save the created multisig
+        {
+            const QString createKey = root.value(QLatin1String("create_key")).toString();
+            if (!createKey.isEmpty()) {
+                const QString progId = root.value(QLatin1String("multisig_program_id")).toString();
+                saveMultisig(QStringLiteral("Multisig ") + createKey.left(8), progId, createKey);
+            }
         }
         emit multisigCreated(resultJson);
     });
@@ -309,4 +319,83 @@ void LezMultisigModule::proposeAsync(const QString& argsJson) {
         return result;
     });
     m_proposeWatcher->setFuture(future);
+}
+
+// ── Multisig Persistence ──────────────────────────────────────────────────────
+
+/*static*/
+QString LezMultisigModule::multisigsFilePath() {
+    const QString dir = QDir::homePath() + QStringLiteral("/.lez");
+    QDir().mkpath(dir);
+    return dir + QStringLiteral("/multisigs.json");
+}
+
+void LezMultisigModule::saveMultisig(const QString& name, const QString& programId, const QString& createKey) {
+    const QString path = multisigsFilePath();
+    QJsonArray arr;
+
+    // Load existing
+    QFile file(path);
+    if (file.open(QIODevice::ReadOnly)) {
+        QJsonParseError err;
+        const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+        if (err.error == QJsonParseError::NoError && doc.isArray())
+            arr = doc.array();
+        file.close();
+    }
+
+    // Check for duplicate (by create_key)
+    for (int i = 0; i < arr.size(); ++i) {
+        if (arr[i].toObject().value(QLatin1String("create_key")).toString() == createKey)
+            return; // Already saved
+    }
+
+    QJsonObject entry;
+    entry[QLatin1String("name")]       = name;
+    entry[QLatin1String("program_id")] = programId;
+    entry[QLatin1String("create_key")] = createKey;
+    arr.append(entry);
+
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(QJsonDocument(arr).toJson(QJsonDocument::Indented));
+        file.close();
+    }
+}
+
+QString LezMultisigModule::loadMultisigs() {
+    const QString path = multisigsFilePath();
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return QStringLiteral("[]");
+    const QByteArray data = file.readAll();
+    file.close();
+    QJsonParseError err;
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isArray())
+        return QStringLiteral("[]");
+    return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+}
+
+void LezMultisigModule::deleteMultisig(const QString& createKey) {
+    const QString path = multisigsFilePath();
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+    QJsonParseError err;
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    file.close();
+    if (err.error != QJsonParseError::NoError || !doc.isArray())
+        return;
+
+    QJsonArray arr = doc.array();
+    QJsonArray filtered;
+    for (int i = 0; i < arr.size(); ++i) {
+        if (arr[i].toObject().value(QLatin1String("create_key")).toString() != createKey)
+            filtered.append(arr[i]);
+    }
+
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(QJsonDocument(filtered).toJson(QJsonDocument::Indented));
+        file.close();
+    }
 }

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -104,6 +104,7 @@ void LezMultisigModule::initLogos(LogosAPI* logosAPIInstance) {
 
     // Create the proposal list model (parented to this module)
     m_model = new ProposalListModel(this);
+    m_model->setObjectName(QStringLiteral("proposalListModel"));
     m_model->setSequencerUrl(m_defaultSequencerUrl);
 
     if (!logosAPI) {

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -284,7 +284,9 @@ void LezMultisigModule::executeAsync(const QString& argsJson) {
 }
 
 void LezMultisigModule::createMultisigAsync(const QString& argsJson) {
+    qInfo() << "createMultisigAsync called with:" << argsJson;
     const QString merged = mergeWithDefaults(argsJson);
+    qInfo() << "Merged args:" << merged;
     QFuture<QString> future = QtConcurrent::run([merged]() -> QString {
         const QByteArray utf8 = merged.toUtf8();
         char* raw = lez_multisig_create(utf8.constData());

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -22,6 +22,13 @@ LezMultisigModule::LezMultisigModule()
     , m_createWatcher(new QFutureWatcher<QString>(this))
     , m_proposeWatcher(new QFutureWatcher<QString>(this))
 {
+    // Create model early so standalone app can find it
+    if (!m_model) {
+        m_model = new ProposalListModel(this);
+        m_model->setObjectName(QStringLiteral("proposalListModel"));
+        m_model->setSequencerUrl(m_defaultSequencerUrl);
+    }
+
     // Proposals refresh completion
     connect(m_refreshWatcher, &QFutureWatcher<QString>::finished, this, [this]() {
         const QString result = m_refreshWatcher->result();
@@ -103,9 +110,11 @@ void LezMultisigModule::initLogos(LogosAPI* logosAPIInstance) {
     logosAPI = logosAPIInstance;
 
     // Create the proposal list model (parented to this module)
-    m_model = new ProposalListModel(this);
-    m_model->setObjectName(QStringLiteral("proposalListModel"));
-    m_model->setSequencerUrl(m_defaultSequencerUrl);
+    if (!m_model) {
+        m_model = new ProposalListModel(this);
+        m_model->setObjectName(QStringLiteral("proposalListModel"));
+        m_model->setSequencerUrl(m_defaultSequencerUrl);
+    }
 
     if (!logosAPI) {
         qWarning() << "LezMultisigModule: initLogos called with null LogosAPI";

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -15,7 +15,7 @@
 // ── Constructor / Destructor ──────────────────────────────────────────────────
 
 LezMultisigModule::LezMultisigModule()
-    : m_defaultSequencerUrl(QStringLiteral("http://localhost:9000"))
+    : m_defaultSequencerUrl(QStringLiteral("http://localhost:3040"))
     , m_defaultWalletPath(QString())
     , m_refreshWatcher(new QFutureWatcher<QString>(this))
     , m_actionWatcher(new QFutureWatcher<QString>(this))

--- a/src/lez_multisig_module.h
+++ b/src/lez_multisig_module.h
@@ -32,7 +32,9 @@ class ProposalListModel;
  */
 class LezMultisigModule final : public QObject, public PluginInterface, public ILezMultisigModule {
     Q_OBJECT
+#ifndef LEZ_MULTISIG_UI_BUILD
     Q_PLUGIN_METADATA(IID ILezMultisigModule_iid FILE LEZ_MULTISIG_MODULE_METADATA_FILE)
+#endif
     Q_INTERFACES(PluginInterface)
 
 public:

--- a/src/lez_multisig_module.h
+++ b/src/lez_multisig_module.h
@@ -67,6 +67,7 @@ public:
     // ── Registry ─────────────────────────────────────────────────────────────
 
     Q_INVOKABLE RegistryBridge* registryBridge() const { return m_registryBridge; }
+    Q_INVOKABLE ProposalListModel* proposalModel() const { return m_model; }
 
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);

--- a/src/lez_multisig_module.h
+++ b/src/lez_multisig_module.h
@@ -15,6 +15,9 @@ extern "C" {
 #include <QVariantList>
 #include <QQmlEngine>
 #include <QFutureWatcher>
+#include <QJsonArray>
+#include <QDir>
+#include <QStandardPaths>
 
 #include "registry_bridge.h"
 
@@ -69,6 +72,11 @@ public:
     Q_INVOKABLE RegistryBridge* registryBridge() const { return m_registryBridge; }
     Q_INVOKABLE ProposalListModel* proposalModel() const { return m_model; }
 
+    // ── Multisig persistence ─────────────────────────────────────────────────
+    Q_INVOKABLE void saveMultisig(const QString& name, const QString& programId, const QString& createKey);
+    Q_INVOKABLE QString loadMultisigs();
+    Q_INVOKABLE void deleteMultisig(const QString& createKey);
+
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
     void proposalsRefreshed(const QString& resultJson);
@@ -96,4 +104,5 @@ private:
 
     QString mergeWithDefaults(const QString& argsJson) const;
     void emitEvent(const QString& eventName, const QVariantList& data);
+    static QString multisigsFilePath();
 };

--- a/src/lez_multisig_module.h
+++ b/src/lez_multisig_module.h
@@ -38,7 +38,7 @@ public:
 
     // ── PluginInterface ──────────────────────────────────────────────────────
 
-    [[nodiscard]] QString name() const override { return QStringLiteral("liblez_multisig_module"); }
+    [[nodiscard]] QString name() const override { return QStringLiteral("lez_multisig_module"); }
     [[nodiscard]] QString version() const override;
 
     // ── ILezMultisigModule lifecycle ─────────────────────────────────────────

--- a/src/lez_multisig_module.h
+++ b/src/lez_multisig_module.h
@@ -39,7 +39,7 @@ public:
     // ── PluginInterface ──────────────────────────────────────────────────────
 
     [[nodiscard]] QString name() const override { return QStringLiteral("lez_multisig_module"); }
-    [[nodiscard]] QString version() const override;
+    Q_INVOKABLE QString version() const override;
 
     // ── ILezMultisigModule lifecycle ─────────────────────────────────────────
 

--- a/ui_metadata.json
+++ b/ui_metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "lez_multisig_ui",
+    "version": "0.1.0",
+    "description": "LEZ Multisig UI Component for logos-app-poc",
+    "author": "jimmy-claw",
+    "type": "ui",
+    "category": "governance"
+}


### PR DESCRIPTION
## Summary

Switches the `lez-multisig-ffi` flake input from the old `lez-multisig` branch to the new `lez-multisig-framework` repo.

## Change

**Before:**
```nix
lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
```

**After:**
```nix
lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework/jimmy/add-nix-flake";
```

## Depends on

- [lez-multisig-framework PR #6](https://github.com/jimmy-claw/lez-multisig-framework/pull/6) — adds top-level `flake.nix` to the framework repo

## All required FFI symbols present ✅

- `lez_multisig_version`
- `lez_multisig_create`
- `lez_multisig_propose`
- `lez_multisig_approve`
- `lez_multisig_reject`
- `lez_multisig_execute`
- `lez_multisig_list_proposals`
- `lez_multisig_get_state`
- `lez_multisig_free_string`

## Notes

- Once framework PR #6 is merged to `main`, update this URL to `github:jimmy-claw/lez-multisig-framework` (no branch suffix)
- The `flake.lock` is updated with the new resolved hash