### PR TITLE
fix: use program_id_hex JSON key to match FFI generated code

### DIFF
--- a/qml/CreateMultisigForm.qml
+++ b/qml/CreateMultisigForm.qml
@@ -286,7 +286,7 @@ Item {
                         }
 
                         var args = {
-                            "multisig_program_id": programIdField.text.trim(),
+                            "program_id_hex": programIdField.text.trim(),
                             "create_key":          createKeyField.text.trim(),
                             "threshold":           parseInt(thresholdField.text) || 2,
                             "members":             lines

--- a/qml/LezMultisigView.qml
+++ b/qml/LezMultisigView.qml
@@ -38,7 +38,7 @@ Item {
     function commonArgs() {
         var args = {}
         if (multisigProgramId.length > 0)
-            args["multisig_program_id"] = multisigProgramId
+            args["program_id_hex"] = multisigProgramId
         if (multisigCreateKey.length > 0)
             args["create_key"] = multisigCreateKey
         return args

--- a/qml/ProposeForm.qml
+++ b/qml/ProposeForm.qml
@@ -717,7 +717,7 @@ Item {
                             .filter(function(n){ return !isNaN(n) })
 
                         var args = {
-                            "multisig_program_id":     root.multisigProgramId,
+                            "program_id_hex":     root.multisigProgramId,
                             "create_key":              root.createKey,
                             "account":                 accountField.text.trim(),
                             "target_program_id":       targetProgIdField.text.trim(),

--- a/src/i_lez_multisig_module.h
+++ b/src/i_lez_multisig_module.h
@@ -28,14 +28,14 @@ public:
 
     /**
      * Create a new M-of-N multisig.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, account, create_key, threshold, members[] }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, account, create_key, threshold, members[] }
      * Returns: { "success": true, "tx_hash": "0x...", "multisig_state_pda": "...", "create_key": "..." }
      */
     virtual QString createMultisig(const QString& argsJson) = 0;
 
     /**
      * Create a new proposal in a multisig.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, account, create_key,
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, account, create_key,
      *             target_program_id, target_instruction_data, target_account_count,
      *             pda_seeds[], authorized_indices[] }
      * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": N, "proposal_pda": "..." }
@@ -44,35 +44,35 @@ public:
 
     /**
      * Approve an existing proposal.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, account, create_key, proposal_index }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, account, create_key, proposal_index }
      * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": N, "action": "approved" }
      */
     virtual QString approve(const QString& argsJson) = 0;
 
     /**
      * Reject an existing proposal.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, account, create_key, proposal_index }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, account, create_key, proposal_index }
      * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": N, "action": "rejected" }
      */
     virtual QString reject(const QString& argsJson) = 0;
 
     /**
      * Execute a fully-approved proposal.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, account, create_key, proposal_index }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, account, create_key, proposal_index }
      * Returns: { "success": true, "tx_hash": "0x..." }
      */
     virtual QString execute(const QString& argsJson) = 0;
 
     /**
      * List proposals for a multisig.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, create_key }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, create_key }
      * Returns: { "success": true, "proposals": [ {...}, ... ] }
      */
     virtual QString listProposals(const QString& argsJson) = 0;
 
     /**
      * Get the state of a multisig.
-     * argsJson: { sequencer_url, wallet_path, multisig_program_id, create_key }
+     * argsJson: { sequencer_url, wallet_path, program_id_hex, create_key }
      * Returns: { "success": true, "state": { threshold, member_count, members[], ... } }
      */
     virtual QString getState(const QString& argsJson) = 0;

--- a/src/lez_multisig_module.cpp
+++ b/src/lez_multisig_module.cpp
@@ -75,7 +75,7 @@ LezMultisigModule::LezMultisigModule()
         {
             const QString createKey = root.value(QLatin1String("create_key")).toString();
             if (!createKey.isEmpty()) {
-                const QString progId = root.value(QLatin1String("multisig_program_id")).toString();
+                const QString progId = root.value(QLatin1String("program_id_hex")).toString();
                 saveMultisig(QStringLiteral("Multisig ") + createKey.left(8), progId, createKey);
             }
         }

--- a/src/proposal_list_model.cpp
+++ b/src/proposal_list_model.cpp
@@ -97,7 +97,7 @@ QHash<int, QByteArray> ProposalListModel::roleNames() const {
 void ProposalListModel::refresh() {
     if (m_loading) return;
     if (m_createKey.isEmpty() || m_multisigProgramId.isEmpty()) {
-        setError(QStringLiteral("create_key and multisig_program_id must be set before refreshing"));
+        setError(QStringLiteral("create_key and program_id_hex must be set before refreshing"));
         return;
     }
     setLoading(true);
@@ -111,7 +111,7 @@ void ProposalListModel::refresh() {
     QFuture<QString> future = QtConcurrent::run([seqUrl, createKey, progId, wallet]() -> QString {
         QJsonObject obj;
         obj[QLatin1String("sequencer_url")]       = seqUrl;
-        obj[QLatin1String("multisig_program_id")] = progId;
+        obj[QLatin1String("program_id_hex")] = progId;
         obj[QLatin1String("create_key")]           = createKey;
         if (!wallet.isEmpty()) {
             obj[QLatin1String("wallet_path")] = wallet;


### PR DESCRIPTION
## Problem

The `lez-multisig-framework` FFI (generated by `lez-client-gen`) uses `program_id_hex` as the JSON key for the program ID. The Qt module was using `multisig_program_id` everywhere, causing a key mismatch that would silently fail.

PR #7 in `lez-multisig-framework` tried to patch the generated code — wrong direction. The fix belongs here.

## Changes

- `qml/CreateMultisigForm.qml`: JSON args key
- `qml/ProposeForm.qml`: JSON args key
- `qml/LezMultisigView.qml`: `commonArgs()` helper
- `src/lez_multisig_module.cpp`: reading `program_id_hex` from FFI result JSON
- `src/proposal_list_model.cpp`: building args JSON + error message
- `src/i_lez_multisig_module.h`: comments only (doc update)

**Note:** C++ property names (`multisigProgramId`, `m_multisigProgramId`) are unchanged — only JSON wire-format string keys updated.