### PR TITLE
feat: add inline registry lookup in ProposeForm

### DIFF
--- a/include/lez_multisig.h
+++ b/include/lez_multisig.h
@@ -1,0 +1,198 @@
+/**
+ * lez_multisig.h — C FFI interface for the LEZ Multisig program
+ *
+ * Enables Logos Core Qt plugins to interact with the LEZ multisig
+ * program without depending on Rust directly.
+ *
+ * All functions take/return JSON strings (UTF-8, null-terminated).
+ * Caller must free returned strings with lez_multisig_free_string().
+ *
+ * JSON error response format:
+ *   { "success": false, "error": "<message>" }
+ *
+ * JSON success response format varies by function (documented inline).
+ */
+
+#ifndef LEZ_MULTISIG_H
+#define LEZ_MULTISIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* ── Multisig Operations ─────────────────────────────────────────────────── */
+
+/**
+ * Create a new M-of-N multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<signer AccountId>",
+ *   "create_key":          "hex64  (unique key for PDA derivation)",
+ *   "threshold":           2,
+ *   "members":             ["hex64", "hex64", ...]
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "tx_hash": "0x...",
+ *   "multisig_state_pda": "...",
+ *   "create_key": "hex64"
+ * }
+ */
+char* lez_multisig_create(const char* args_json);
+
+/**
+ * Create a new proposal in a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":           "http://...",
+ *   "wallet_path":             "...",
+ *   "multisig_program_id":     "hex64",
+ *   "account":                 "<proposer AccountId>",
+ *   "create_key":              "hex64",
+ *   "target_program_id":       "hex64",
+ *   "target_instruction_data": "hex (encoded bytes)",
+ *   "target_account_count":    3,
+ *   "pda_seeds":               ["hex64", ...],
+ *   "authorized_indices":      [0, 1]
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "tx_hash": "0x...",
+ *   "proposal_index": 1,
+ *   "proposal_pda": "..."
+ * }
+ */
+char* lez_multisig_propose(const char* args_json);
+
+/**
+ * Approve an existing proposal.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<approver AccountId>",
+ *   "create_key":          "hex64",
+ *   "proposal_index":      1
+ * }
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1, "action": "approved" }
+ */
+char* lez_multisig_approve(const char* args_json);
+
+/**
+ * Reject an existing proposal.
+ *
+ * args_json: (same as approve)
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1, "action": "rejected" }
+ */
+char* lez_multisig_reject(const char* args_json);
+
+/**
+ * Execute a fully-approved proposal.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<executor AccountId>",
+ *   "create_key":          "hex64",
+ *   "proposal_index":      1
+ * }
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1 }
+ */
+char* lez_multisig_execute(const char* args_json);
+
+/**
+ * List proposals for a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "create_key":          "hex64"
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "proposals": [
+ *     {
+ *       "index": 1,
+ *       "proposer": "hex64",
+ *       "target_program_id": "hex64",
+ *       "target_account_count": 3,
+ *       "approved_count": 2,
+ *       "rejected_count": 0,
+ *       "status": "Active|Approved|Rejected|Executed",
+ *       "proposal_pda": "..."
+ *     },
+ *     ...
+ *   ],
+ *   "transaction_index": 3
+ * }
+ */
+char* lez_multisig_list_proposals(const char* args_json);
+
+/**
+ * Get the state of a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "create_key":          "hex64"
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "state": {
+ *     "create_key": "hex64",
+ *     "threshold": 2,
+ *     "member_count": 3,
+ *     "members": ["hex64", ...],
+ *     "transaction_index": 5
+ *   },
+ *   "multisig_state_pda": "..."
+ * }
+ */
+char* lez_multisig_get_state(const char* args_json);
+
+/* ── Memory Management ───────────────────────────────────────────────────── */
+
+/**
+ * Free a string returned by any lez_multisig_* function.
+ * Must be called for every non-NULL return value to avoid memory leaks.
+ */
+void lez_multisig_free_string(char* s);
+
+
+/* ── IDL ─────────────────────────────────────────────────────────────────── */
+
+/**
+ * Returns the program IDL as a JSON string (embedded at compile time).
+ * Caller must free with lez_multisig_free_string().
+ */
+const char* lez_multisig_get_idl(void);
+
+/* ── Version Info ────────────────────────────────────────────────────────── */
+
+/**
+ * Returns the version string of this FFI library.
+ * Caller must free with lez_multisig_free_string().
+ */
+char* lez_multisig_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEZ_MULTISIG_H */

--- a/qml/ProposeForm.qml
+++ b/qml/ProposeForm.qml
@@ -268,6 +268,31 @@ Item {
         }
     }
 
+
+    // ── Inline registry lookup timer ─────────────────────────────────────────
+    Timer {
+        id: registryLookupTimer
+        interval: 500
+        repeat: false
+        onTriggered: {
+            var pid = targetProgIdField.text.trim()
+            if (pid.length !== 64) return
+            if (typeof lezRegistryBridge === "undefined" || !lezRegistryBridge || !lezRegistryBridge.isLoaded) {
+                inlineProgramNameLabel.text = ""
+                inlineProgramDescLabel.text = ""
+                return
+            }
+            var prog = lezRegistryBridge.getProgramById(root.sequencerUrl, pid)
+            if (prog && prog.name) {
+                inlineProgramNameLabel.text = prog.name + (prog.version ? "  v" + prog.version : "")
+                inlineProgramDescLabel.text = prog.description || ""
+            } else {
+                inlineProgramNameLabel.text = ""
+                inlineProgramDescLabel.text = lezRegistryBridge.lastError() || ""
+            }
+        }
+    }
+
     // ── Main layout ───────────────────────────────────────────────────────────
     ColumnLayout {
         anchors { fill: parent; margins: Theme.spacing.large }
@@ -400,6 +425,51 @@ Item {
                         placeholderText: "64 hex chars — or use Browse Registry above"
                         placeholderTextColor: Theme.palette.textTertiary
                         font { pixelSize: 13; family: "monospace" }
+                        onTextChanged: {
+                            inlineProgramNameLabel.text = ""
+                            inlineProgramDescLabel.text = ""
+                            if (text.trim().length === 64) {
+                                registryLookupTimer.restart()
+                            } else {
+                                registryLookupTimer.stop()
+                            }
+                        }
+                    }
+                }
+
+                // ── Inline registry lookup result ─────────────────────────────
+                Rectangle {
+                    id: inlineLookupResult
+                    visible: inlineProgramNameLabel.text.length > 0 || inlineProgramDescLabel.text.length > 0
+                    Layout.fillWidth: true
+                    height: inlineLookupCol.implicitHeight + 12
+                    radius: Theme.spacing.tiny
+                    color: inlineProgramNameLabel.text.length > 0 ? "#1a3a1a" : "#2a1a1a"
+                    border {
+                        color: inlineProgramNameLabel.text.length > 0 ? Theme.palette.success : Theme.palette.error
+                        width: 1
+                    }
+                    ColumnLayout {
+                        id: inlineLookupCol
+                        anchors { left: parent.left; right: parent.right; top: parent.top; margins: 8 }
+                        spacing: 2
+                        Text {
+                            id: inlineProgramNameLabel
+                            text: ""
+                            color: Theme.palette.success
+                            font { pixelSize: 13; bold: true }
+                            visible: text.length > 0
+                            Layout.fillWidth: true
+                        }
+                        Text {
+                            id: inlineProgramDescLabel
+                            text: ""
+                            color: inlineProgramNameLabel.text.length > 0 ? Theme.palette.textSecondary : Theme.palette.error
+                            font.pixelSize: 11
+                            visible: text.length > 0
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

When a user types a full 64-character program ID hex into the **Target Program ID** field in `ProposeForm`, a debounced timer (500ms) fires and calls `lezRegistryBridge.getProgramById()` to look up the program in the registry.

## What changed

### `qml/ProposeForm.qml`
- Added `Timer { id: registryLookupTimer; interval: 500 }` — debounces the registry lookup
- Added `onTextChanged` to `targetProgIdField` — restarts the timer when user types a 64-char ID
- Added inline result display below the field:
  - **Green** label shows program name + version when found
  - **Gray** label shows description
  - **Red** label shows error if not found or registry unavailable
  - Result panel is hidden when field is empty or < 64 chars

### `include/lez_multisig.h`
- Bundled the generated C header so cmake builds work without needing `LEZ_MULTISIG_INCLUDE` to be set explicitly

## Behavior

| Scenario | Result |
|---|---|
| User types < 64 chars | No lookup, result panel hidden |
| User types 64-char ID | 500ms debounce then lookup fires |
| Program found in registry | Name (green) + description shown |
| Program not in registry | Error message shown in red |
| Registry FFI not loaded | Silently does nothing (graceful degradation) |
| User uses Browse Registry popup | Works as before, also sets selectedProgramLabel |

## Tested
- ✅ Builds successfully with cmake (Debug)
- ✅ No new warnings beyond pre-existing ones

## Architecture notes
The `lezRegistryBridge` context property is set in `LezMultisigModule::initLogos()` and calls `RegistryBridge::loadLibrary()` which uses `QLibrary` to dlopen `liblez_registry_ffi.so`. The bridge was already fully implemented — this PR just wires it up in the QML form.