### PR TITLE
fix: correct FFI header field name multisig_program_id → program_id_hex

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -34,6 +34,13 @@ int main(int argc, char *argv[])
         std::cerr << "Failed to load capability_module plugin" << std::endl;
     }
 
+    // Load lez_registry_module (no deps beyond capability)
+    if (logos_core_load_plugin("lez_registry_module")) {
+        std::cout << "Successfully loaded lez_registry_module plugin" << std::endl;
+    } else {
+        std::cerr << "Failed to load lez_registry_module plugin" << std::endl;
+    }
+
     // Then load lez_multisig_module
     if (logos_core_load_plugin("lez_multisig_module")) {
         std::cout << "Successfully loaded lez_multisig_module plugin" << std::endl;
@@ -53,7 +60,7 @@ int main(int argc, char *argv[])
     MainWindow window;
     window.show();
 
-    std::cout << "LEZ Multisig App running — close window to exit." << std::endl;
+    std::cout << "LEZ Unified App running — close window to exit." << std::endl;
 
     int result = app.exec();
     logos_core_cleanup();

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -12,6 +12,7 @@
 #include <QQmlContext>
 #include <QUrl>
 #include <QFile>
+#include <iostream>
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -34,48 +35,80 @@ void MainWindow::setupUi()
         pluginExtension = ".so";
     #endif
 
-    QString pluginPath = QCoreApplication::applicationDirPath() + "/../modules/liblez_multisig_module" + pluginExtension;
-    QPluginLoader loader(pluginPath);
+    // ── Load multisig plugin ─────────────────────────────────────────────────
+    QString multisigPluginPath = QCoreApplication::applicationDirPath() + "/../modules/liblez_multisig_module" + pluginExtension;
+    QPluginLoader multisigLoader(multisigPluginPath);
 
-    QObject* pluginObj = nullptr;
-    if (loader.load()) {
-        pluginObj = loader.instance();
-        if (pluginObj) {
-            qInfo() << "LEZ Multisig module plugin loaded successfully";
+    QObject* multisigPluginObj = nullptr;
+    if (multisigLoader.load()) {
+        multisigPluginObj = multisigLoader.instance();
+        if (multisigPluginObj) {
+            std::cout << "[QPluginLoader] LEZ Multisig module loaded successfully" << std::endl;
         }
     } else {
-        qWarning() << "Failed to load LEZ Multisig module from:" << pluginPath;
-        qWarning() << "Error:" << loader.errorString();
+        std::cerr << "[QPluginLoader] Failed to load LEZ Multisig module: "
+                  << multisigLoader.errorString().toStdString() << std::endl;
     }
 
+    // ── Load registry plugin ─────────────────────────────────────────────────
+    QString registryPluginPath = QCoreApplication::applicationDirPath() + "/../modules/liblez_registry_module" + pluginExtension;
+    QPluginLoader registryLoader(registryPluginPath);
+
+    QObject* registryPluginObj = nullptr;
+    if (registryLoader.load()) {
+        registryPluginObj = registryLoader.instance();
+        if (registryPluginObj) {
+            std::cout << "[QPluginLoader] LEZ Registry module loaded successfully" << std::endl;
+        }
+    } else {
+        std::cerr << "[QPluginLoader] Failed to load LEZ Registry module: "
+                  << registryLoader.errorString().toStdString() << std::endl;
+    }
+
+    // ── Create QML widget ────────────────────────────────────────────────────
     m_quickWidget = new QQuickWidget(this);
     m_quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
 
     QString qmlDir = QCoreApplication::applicationDirPath() + "/../qml";
     m_quickWidget->engine()->addImportPath(qmlDir);
 
-    QUrl qmlUrl;
-    QString localQml = qmlDir + "/LezMultisigView.qml";
-    if (QFile::exists(localQml)) {
-        qmlUrl = QUrl::fromLocalFile(localQml);
-    } else {
-        qmlUrl = QUrl("qrc:/qml/LezMultisigView.qml");
-    }
-
-    // Expose plugin to QML as context properties
-    if (pluginObj) {
+    // ── Expose multisig context properties ───────────────────────────────────
+    if (multisigPluginObj) {
         m_quickWidget->engine()->rootContext()->setContextProperty(
-            QStringLiteral("lezMultisigModule"), pluginObj);
-        // Find the ProposalListModel child object
-        QObject* model = pluginObj->findChild<QObject*>(QStringLiteral("proposalListModel"));
+            QStringLiteral("lezMultisigModule"), multisigPluginObj);
+        QObject* model = multisigPluginObj->findChild<QObject*>(QStringLiteral("proposalListModel"));
         if (model) {
             m_quickWidget->engine()->rootContext()->setContextProperty(
                 QStringLiteral("lezMultisigModel"), model);
-            qInfo() << "ProposalListModel exposed to QML";
+            std::cout << "[Context] lezMultisigModel exposed to QML" << std::endl;
         } else {
-            qInfo() << "ProposalListModel not found - QML will use demo data";
+            std::cout << "[Context] ProposalListModel not found — QML will use demo data" << std::endl;
         }
-        qInfo() << "Context properties set for QML";
+    }
+
+    // ── Expose registry context properties ───────────────────────────────────
+    if (registryPluginObj) {
+        m_quickWidget->engine()->rootContext()->setContextProperty(
+            QStringLiteral("lezRegistryModule"), registryPluginObj);
+        QObject* registryModel = registryPluginObj->findChild<QObject*>(QStringLiteral("programListModel"));
+        if (registryModel) {
+            m_quickWidget->engine()->rootContext()->setContextProperty(
+                QStringLiteral("lezRegistryModel"), registryModel);
+            std::cout << "[Context] lezRegistryModel exposed to QML" << std::endl;
+        } else {
+            std::cout << "[Context] ProgramListModel not found — Registry QML will use fallback" << std::endl;
+        }
+    }
+
+    std::cout << "[Context] All context properties set for QML" << std::endl;
+
+    // ── Load unified QML view ────────────────────────────────────────────────
+    QUrl qmlUrl;
+    QString localQml = qmlDir + "/UnifiedView.qml";
+    if (QFile::exists(localQml)) {
+        qmlUrl = QUrl::fromLocalFile(localQml);
+    } else {
+        qmlUrl = QUrl("qrc:/qml/UnifiedView.qml");
     }
 
     m_quickWidget->setSource(qmlUrl);
@@ -87,7 +120,7 @@ void MainWindow::setupUi()
         }
         QWidget* fallbackWidget = new QWidget(this);
         QVBoxLayout* layout = new QVBoxLayout(fallbackWidget);
-        QLabel* messageLabel = new QLabel("LEZ Multisig QML view failed to load", fallbackWidget);
+        QLabel* messageLabel = new QLabel("LEZ Unified QML view failed to load", fallbackWidget);
         QFont font = messageLabel->font();
         font.setPointSize(14);
         messageLabel->setFont(font);
@@ -98,6 +131,6 @@ void MainWindow::setupUi()
         setCentralWidget(m_quickWidget);
     }
 
-    setWindowTitle("LEZ Multisig");
-    resize(800, 600);
+    setWindowTitle("LEZ Unified App");
+    resize(900, 700);
 }

--- a/flake.lock
+++ b/flake.lock
@@ -247,6 +247,40 @@
         "type": "github"
       }
     },
+    "logos-lez-registry-module": {
+      "inputs": {
+        "lez-registry-ffi": [
+          "lez-registry-ffi"
+        ],
+        "logos-capability-module": [
+          "logos-capability-module"
+        ],
+        "logos-cpp-sdk": [
+          "logos-cpp-sdk"
+        ],
+        "logos-liblogos": [
+          "logos-liblogos"
+        ],
+        "nixpkgs": [
+          "logos-lez-registry-module",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772126980,
+        "narHash": "sha256-wOQixG/jRvcF05nlMIyDH4/BD0bgw61G+0nXpJwQ+3E=",
+        "owner": "jimmy-claw",
+        "repo": "logos-lez-registry-module",
+        "rev": "903e8d529bced479297f0d4dd364437d4927d4eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jimmy-claw",
+        "repo": "logos-lez-registry-module",
+        "type": "github"
+      }
+    },
     "logos-liblogos": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_2",
@@ -495,6 +529,7 @@
         "lez-registry-ffi": "lez-registry-ffi",
         "logos-capability-module": "logos-capability-module",
         "logos-cpp-sdk": "logos-cpp-sdk_3",
+        "logos-lez-registry-module": "logos-lez-registry-module",
         "logos-liblogos": "logos-liblogos_2",
         "nixpkgs": [
           "logos-liblogos",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1771796463,
-        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
+        "lastModified": 1772080396,
+        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
+        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
         "type": "github"
       },
       "original": {
@@ -37,19 +37,17 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "dir": "lez-multisig-ffi",
-        "lastModified": 1772014708,
-        "narHash": "sha256-rImGqowH0WKm9vpHhVljO7JPhBZQhUpaT1N1X0gNw2w=",
+        "lastModified": 1772123671,
+        "narHash": "sha256-wxnGmugVni2fTgytdTUXcFsKzc+azguTDqEwKNXp+1o=",
         "owner": "jimmy-claw",
-        "repo": "lez-multisig",
-        "rev": "89b500d374c3cf0278a1e54d3fc037b3fa444d59",
+        "repo": "lez-multisig-framework",
+        "rev": "7f96e3ecd124c945de23a759ea146b8f7c7fc3bb",
         "type": "github"
       },
       "original": {
-        "dir": "lez-multisig-ffi",
         "owner": "jimmy-claw",
-        "ref": "jimmy/nssa-framework-migration",
-        "repo": "lez-multisig",
+        "ref": "jimmy/add-nix-flake",
+        "repo": "lez-multisig-framework",
         "type": "github"
       }
     },
@@ -513,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771988922,
-        "narHash": "sha256-Fc6FHXtfEkLtuVJzd0B6tFYMhmcPLuxr90rWfb/2jtQ=",
+        "lastModified": 1772075164,
+        "narHash": "sha256-93XcvAt+6p7aAq1ERlxD2T17zLGoYGo64KJYasGcpgc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f4443dc3f0b6c5e6b77d923156943ce816d1fcb9",
+        "rev": "07601339b15fa6810541c0e7dc2f3664d92a7ad0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772123671,
+        "lastModified": 1772127532,
         "narHash": "sha256-wxnGmugVni2fTgytdTUXcFsKzc+azguTDqEwKNXp+1o=",
         "owner": "jimmy-claw",
         "repo": "lez-multisig-framework",
-        "rev": "7f96e3ecd124c945de23a759ea146b8f7c7fc3bb",
+        "rev": "dc205880e13e8f972932b5241312eb13679567af",
         "type": "github"
       },
       "original": {
         "owner": "jimmy-claw",
-        "ref": "jimmy/add-nix-flake",
         "repo": "lez-multisig-framework",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework/jimmy/add-nix-flake";
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
 
-    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig?dir=lez-multisig-ffi&ref=jimmy/nssa-framework-migration";
+    lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework/jimmy/add-nix-flake";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,14 @@
 
     lez-multisig-ffi.url = "github:jimmy-claw/lez-multisig-framework";
     lez-registry-ffi.url = "github:jimmy-claw/lez-registry?dir=lez-registry-ffi";
+
+    logos-lez-registry-module = {
+      url = "github:jimmy-claw/logos-lez-registry-module";
+      inputs.logos-liblogos.follows = "logos-liblogos";
+      inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
+      inputs.logos-capability-module.follows = "logos-capability-module";
+      inputs.lez-registry-ffi.follows = "lez-registry-ffi";
+    };
   };
 
   outputs =
@@ -21,6 +29,7 @@
       logos-capability-module,
       lez-multisig-ffi,
       lez-registry-ffi,
+      logos-lez-registry-module,
       ...
     }:
     let
@@ -32,10 +41,11 @@
         logosCapabilityModule = logos-capability-module.packages.${system}.default;
         lezMultisigFfi = lez-multisig-ffi.packages.${system}.default;
         lezRegistryFfi = lez-registry-ffi.packages.${system}.default;
+        lezRegistryModule = logos-lez-registry-module.packages.${system}.default;
       });
     in
     {
-      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi }:
+      packages = forAllSystems ({ pkgs, logosSdk, logosLiblogos, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi, lezRegistryModule }:
         let
           common = import ./nix/default.nix {
             inherit pkgs logosSdk logosLiblogos;
@@ -47,7 +57,7 @@
           };
 
           app = import ./nix/app.nix {
-            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi;
+            inherit pkgs common src logosLiblogos logosSdk logosCapabilityModule lezMultisigFfi lezRegistryFfi lezRegistryModule;
             lezMultisigModule = lib;
           };
 

--- a/include/lez_multisig.h
+++ b/include/lez_multisig.h
@@ -1,0 +1,198 @@
+/**
+ * lez_multisig.h — C FFI interface for the LEZ Multisig program
+ *
+ * Enables Logos Core Qt plugins to interact with the LEZ multisig
+ * program without depending on Rust directly.
+ *
+ * All functions take/return JSON strings (UTF-8, null-terminated).
+ * Caller must free returned strings with lez_multisig_free_string().
+ *
+ * JSON error response format:
+ *   { "success": false, "error": "<message>" }
+ *
+ * JSON success response format varies by function (documented inline).
+ */
+
+#ifndef LEZ_MULTISIG_H
+#define LEZ_MULTISIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* ── Multisig Operations ─────────────────────────────────────────────────── */
+
+/**
+ * Create a new M-of-N multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<signer AccountId>",
+ *   "create_key":          "hex64  (unique key for PDA derivation)",
+ *   "threshold":           2,
+ *   "members":             ["hex64", "hex64", ...]
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "tx_hash": "0x...",
+ *   "multisig_state_pda": "...",
+ *   "create_key": "hex64"
+ * }
+ */
+char* lez_multisig_create(const char* args_json);
+
+/**
+ * Create a new proposal in a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":           "http://...",
+ *   "wallet_path":             "...",
+ *   "multisig_program_id":     "hex64",
+ *   "account":                 "<proposer AccountId>",
+ *   "create_key":              "hex64",
+ *   "target_program_id":       "hex64",
+ *   "target_instruction_data": "hex (encoded bytes)",
+ *   "target_account_count":    3,
+ *   "pda_seeds":               ["hex64", ...],
+ *   "authorized_indices":      [0, 1]
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "tx_hash": "0x...",
+ *   "proposal_index": 1,
+ *   "proposal_pda": "..."
+ * }
+ */
+char* lez_multisig_propose(const char* args_json);
+
+/**
+ * Approve an existing proposal.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<approver AccountId>",
+ *   "create_key":          "hex64",
+ *   "proposal_index":      1
+ * }
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1, "action": "approved" }
+ */
+char* lez_multisig_approve(const char* args_json);
+
+/**
+ * Reject an existing proposal.
+ *
+ * args_json: (same as approve)
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1, "action": "rejected" }
+ */
+char* lez_multisig_reject(const char* args_json);
+
+/**
+ * Execute a fully-approved proposal.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "account":             "<executor AccountId>",
+ *   "create_key":          "hex64",
+ *   "proposal_index":      1
+ * }
+ *
+ * Returns: { "success": true, "tx_hash": "0x...", "proposal_index": 1 }
+ */
+char* lez_multisig_execute(const char* args_json);
+
+/**
+ * List proposals for a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "create_key":          "hex64"
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "proposals": [
+ *     {
+ *       "index": 1,
+ *       "proposer": "hex64",
+ *       "target_program_id": "hex64",
+ *       "target_account_count": 3,
+ *       "approved_count": 2,
+ *       "rejected_count": 0,
+ *       "status": "Active|Approved|Rejected|Executed",
+ *       "proposal_pda": "..."
+ *     },
+ *     ...
+ *   ],
+ *   "transaction_index": 3
+ * }
+ */
+char* lez_multisig_list_proposals(const char* args_json);
+
+/**
+ * Get the state of a multisig.
+ *
+ * args_json: {
+ *   "sequencer_url":       "http://...",
+ *   "wallet_path":         "...",
+ *   "multisig_program_id": "hex64",
+ *   "create_key":          "hex64"
+ * }
+ *
+ * Returns: {
+ *   "success": true,
+ *   "state": {
+ *     "create_key": "hex64",
+ *     "threshold": 2,
+ *     "member_count": 3,
+ *     "members": ["hex64", ...],
+ *     "transaction_index": 5
+ *   },
+ *   "multisig_state_pda": "..."
+ * }
+ */
+char* lez_multisig_get_state(const char* args_json);
+
+/* ── Memory Management ───────────────────────────────────────────────────── */
+
+/**
+ * Free a string returned by any lez_multisig_* function.
+ * Must be called for every non-NULL return value to avoid memory leaks.
+ */
+void lez_multisig_free_string(char* s);
+
+
+/* ── IDL ─────────────────────────────────────────────────────────────────── */
+
+/**
+ * Returns the program IDL as a JSON string (embedded at compile time).
+ * Caller must free with lez_multisig_free_string().
+ */
+const char* lez_multisig_get_idl(void);
+
+/* ── Version Info ────────────────────────────────────────────────────────── */
+
+/**
+ * Returns the version string of this FFI library.
+ * Caller must free with lez_multisig_free_string().
+ */
+char* lez_multisig_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEZ_MULTISIG_H */

--- a/include/lez_multisig.h
+++ b/include/lez_multisig.h
@@ -30,7 +30,7 @@ extern "C" {
  * args_json: {
  *   "sequencer_url":       "http://...",
  *   "wallet_path":         "...",
- *   "multisig_program_id": "hex64",
+ *   "program_id_hex": "hex64",
  *   "account":             "<signer AccountId>",
  *   "create_key":          "hex64  (unique key for PDA derivation)",
  *   "threshold":           2,
@@ -52,7 +52,7 @@ char* lez_multisig_create(const char* args_json);
  * args_json: {
  *   "sequencer_url":           "http://...",
  *   "wallet_path":             "...",
- *   "multisig_program_id":     "hex64",
+ *   "program_id_hex":     "hex64",
  *   "account":                 "<proposer AccountId>",
  *   "create_key":              "hex64",
  *   "target_program_id":       "hex64",
@@ -77,7 +77,7 @@ char* lez_multisig_propose(const char* args_json);
  * args_json: {
  *   "sequencer_url":       "http://...",
  *   "wallet_path":         "...",
- *   "multisig_program_id": "hex64",
+ *   "program_id_hex": "hex64",
  *   "account":             "<approver AccountId>",
  *   "create_key":          "hex64",
  *   "proposal_index":      1
@@ -102,7 +102,7 @@ char* lez_multisig_reject(const char* args_json);
  * args_json: {
  *   "sequencer_url":       "http://...",
  *   "wallet_path":         "...",
- *   "multisig_program_id": "hex64",
+ *   "program_id_hex": "hex64",
  *   "account":             "<executor AccountId>",
  *   "create_key":          "hex64",
  *   "proposal_index":      1
@@ -118,7 +118,7 @@ char* lez_multisig_execute(const char* args_json);
  * args_json: {
  *   "sequencer_url":       "http://...",
  *   "wallet_path":         "...",
- *   "multisig_program_id": "hex64",
+ *   "program_id_hex": "hex64",
  *   "create_key":          "hex64"
  * }
  *
@@ -148,7 +148,7 @@ char* lez_multisig_list_proposals(const char* args_json);
  * args_json: {
  *   "sequencer_url":       "http://...",
  *   "wallet_path":         "...",
- *   "multisig_program_id": "hex64",
+ *   "program_id_hex": "hex64",
  *   "create_key":          "hex64"
  * }
  *

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -1,5 +1,5 @@
 # Builds the logos-lez-multisig-app standalone application
-{ pkgs, common, src, logosLiblogos, logosSdk, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi, lezMultisigModule }:
+{ pkgs, common, src, logosLiblogos, logosSdk, logosCapabilityModule, lezMultisigFfi, lezRegistryFfi, lezMultisigModule, lezRegistryModule }:
 
 pkgs.stdenv.mkDerivation rec {
   pname = "logos-lez-multisig-app";
@@ -102,11 +102,13 @@ pkgs.stdenv.mkDerivation rec {
     echo "capability-module: ${logosCapabilityModule}"
     echo "lez-multisig-ffi: ${lezMultisigFfi}"
     echo "lez-multisig-module: ${lezMultisigModule}"
+    echo "lez-registry-module: ${lezRegistryModule}"
 
     test -d "${logosLiblogos}" || (echo "liblogos not found" && exit 1)
     test -d "${logosSdk}" || (echo "cpp-sdk not found" && exit 1)
     test -d "${logosCapabilityModule}" || (echo "capability-module not found" && exit 1)
     test -d "${lezMultisigModule}" || (echo "lez-multisig-module not found" && exit 1)
+    test -d "${lezRegistryModule}" || (echo "lez-registry-module not found" && exit 1)
 
     cmake -S app -B build \
       -GNinja \
@@ -158,6 +160,11 @@ pkgs.stdenv.mkDerivation rec {
       cp -L "${lezMultisigFfi}/lib/"liblez_multisig_ffi.* "$out/lib/" || true
     fi
 
+    # Copy lez-registry-ffi library
+    if ls "${lezRegistryFfi}/lib/"liblez_registry_ffi.* >/dev/null 2>&1; then
+      cp -L "${lezRegistryFfi}/lib/"liblez_registry_ffi.* "$out/lib/" || true
+    fi
+
     # Determine plugin extension
     OS_EXT="so"
     case "$(uname -s)" in
@@ -170,6 +177,9 @@ pkgs.stdenv.mkDerivation rec {
     fi
     if [ -f "${lezMultisigModule}/lib/liblez_multisig_module.$OS_EXT" ]; then
       cp -L "${lezMultisigModule}/lib/liblez_multisig_module.$OS_EXT" "$out/modules/"
+    fi
+    if [ -f "${lezRegistryModule}/lib/liblez_registry_module.$OS_EXT" ]; then
+      cp -L "${lezRegistryModule}/lib/liblez_registry_module.$OS_EXT" "$out/modules/"
     fi
 
     # Copy QML files for the app to find

--- a/qml/ProposeForm.qml
+++ b/qml/ProposeForm.qml
@@ -268,6 +268,31 @@ Item {
         }
     }
 
+
+    // ── Inline registry lookup timer ─────────────────────────────────────────
+    Timer {
+        id: registryLookupTimer
+        interval: 500
+        repeat: false
+        onTriggered: {
+            var pid = targetProgIdField.text.trim()
+            if (pid.length !== 64) return
+            if (typeof lezRegistryBridge === "undefined" || !lezRegistryBridge || !lezRegistryBridge.isLoaded) {
+                inlineProgramNameLabel.text = ""
+                inlineProgramDescLabel.text = ""
+                return
+            }
+            var prog = lezRegistryBridge.getProgramById(root.sequencerUrl, pid)
+            if (prog && prog.name) {
+                inlineProgramNameLabel.text = prog.name + (prog.version ? "  v" + prog.version : "")
+                inlineProgramDescLabel.text = prog.description || ""
+            } else {
+                inlineProgramNameLabel.text = ""
+                inlineProgramDescLabel.text = lezRegistryBridge.lastError() || ""
+            }
+        }
+    }
+
     // ── Main layout ───────────────────────────────────────────────────────────
     ColumnLayout {
         anchors { fill: parent; margins: Theme.spacing.large }
@@ -400,6 +425,51 @@ Item {
                         placeholderText: "64 hex chars — or use Browse Registry above"
                         placeholderTextColor: Theme.palette.textTertiary
                         font { pixelSize: 13; family: "monospace" }
+                        onTextChanged: {
+                            inlineProgramNameLabel.text = ""
+                            inlineProgramDescLabel.text = ""
+                            if (text.trim().length === 64) {
+                                registryLookupTimer.restart()
+                            } else {
+                                registryLookupTimer.stop()
+                            }
+                        }
+                    }
+                }
+
+                // ── Inline registry lookup result ─────────────────────────────
+                Rectangle {
+                    id: inlineLookupResult
+                    visible: inlineProgramNameLabel.text.length > 0 || inlineProgramDescLabel.text.length > 0
+                    Layout.fillWidth: true
+                    height: inlineLookupCol.implicitHeight + 12
+                    radius: Theme.spacing.tiny
+                    color: inlineProgramNameLabel.text.length > 0 ? "#1a3a1a" : "#2a1a1a"
+                    border {
+                        color: inlineProgramNameLabel.text.length > 0 ? Theme.palette.success : Theme.palette.error
+                        width: 1
+                    }
+                    ColumnLayout {
+                        id: inlineLookupCol
+                        anchors { left: parent.left; right: parent.right; top: parent.top; margins: 8 }
+                        spacing: 2
+                        Text {
+                            id: inlineProgramNameLabel
+                            text: ""
+                            color: Theme.palette.success
+                            font { pixelSize: 13; bold: true }
+                            visible: text.length > 0
+                            Layout.fillWidth: true
+                        }
+                        Text {
+                            id: inlineProgramDescLabel
+                            text: ""
+                            color: inlineProgramNameLabel.text.length > 0 ? Theme.palette.textSecondary : Theme.palette.error
+                            font.pixelSize: 11
+                            visible: text.length > 0
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
                     }
                 }
 

--- a/qml/UnifiedView.qml
+++ b/qml/UnifiedView.qml
@@ -1,0 +1,86 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+
+    Rectangle {
+        anchors.fill: parent
+        color: "#1a1a2e"
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // ── Tab bar ──────────────────────────────────────────────────────────
+        TabBar {
+            id: tabBar
+            Layout.fillWidth: true
+
+            background: Rectangle { color: "#16213e" }
+
+            TabButton {
+                text: "Multisig"
+                width: implicitWidth
+                contentItem: Text {
+                    text: parent.text
+                    color: tabBar.currentIndex === 0 ? "#f5a623" : "#A4A4A4"
+                    font.pixelSize: 14
+                    font.bold: tabBar.currentIndex === 0
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+                background: Rectangle {
+                    color: tabBar.currentIndex === 0 ? "#1a1a2e" : "#16213e"
+                    Rectangle {
+                        anchors.bottom: parent.bottom
+                        width: parent.width
+                        height: 2
+                        color: "#f5a623"
+                        visible: tabBar.currentIndex === 0
+                    }
+                }
+            }
+
+            TabButton {
+                text: "Registry"
+                width: implicitWidth
+                contentItem: Text {
+                    text: parent.text
+                    color: tabBar.currentIndex === 1 ? "#f5a623" : "#A4A4A4"
+                    font.pixelSize: 14
+                    font.bold: tabBar.currentIndex === 1
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+                background: Rectangle {
+                    color: tabBar.currentIndex === 1 ? "#1a1a2e" : "#16213e"
+                    Rectangle {
+                        anchors.bottom: parent.bottom
+                        width: parent.width
+                        height: 2
+                        color: "#f5a623"
+                        visible: tabBar.currentIndex === 1
+                    }
+                }
+            }
+        }
+
+        // ── Content area ─────────────────────────────────────────────────────
+        StackLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            currentIndex: tabBar.currentIndex
+
+            Loader {
+                source: "LezMultisigView.qml"
+            }
+
+            Loader {
+                source: "qrc:/lez-registry/LezRegistryView.qml"
+            }
+        }
+    }
+}

--- a/tests/headless_cli_test.sh
+++ b/tests/headless_cli_test.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# headless_cli_test.sh — Prove Logos Core plugin interface works headlessly
+#
+# Tests two paths:
+#   1. logoscore --call (full plugin stack via QtRemoteObjects)
+#   2. Direct FFI via Python ctypes (bypasses Logos Core)
+#
+# Exit codes: 0 = all tests pass, 1 = failures detected
+set -euo pipefail
+
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESULT_DIR="$MODULE_DIR/result"
+MULTISIG_FFI="$RESULT_DIR/lib/liblez_multisig_ffi.so"
+LOGOSCORE="$RESULT_DIR/bin/logoscore"
+MODULES_DIR="$RESULT_DIR/modules"
+SEQUENCER_URL="${SEQUENCER_URL:-http://127.0.0.1:3040}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1 — $2"; SKIP=$((SKIP + 1)); }
+
+echo "============================================"
+echo "  Logos Core Headless CLI Test Suite"
+echo "============================================"
+echo ""
+echo "Module dir:    $MODULE_DIR"
+echo "Result dir:    $RESULT_DIR"
+echo "Sequencer URL: $SEQUENCER_URL"
+echo ""
+
+# ── Pre-flight checks ─────────────────────────────────────────────────────────
+
+echo "── Pre-flight Checks ──"
+
+if [[ -x "$LOGOSCORE" ]]; then
+    pass "logoscore binary exists and is executable"
+else
+    fail "logoscore binary" "not found at $LOGOSCORE"
+fi
+
+if [[ -f "$MULTISIG_FFI" ]]; then
+    pass "liblez_multisig_ffi.so exists"
+else
+    fail "liblez_multisig_ffi.so" "not found at $MULTISIG_FFI"
+fi
+
+if [[ -f "$MODULES_DIR/liblez_multisig_module.so" ]]; then
+    pass "multisig plugin .so exists"
+else
+    fail "multisig plugin" "not found in $MODULES_DIR"
+fi
+
+if [[ -f "$MODULES_DIR/capability_module_plugin.so" ]]; then
+    pass "capability_module plugin .so exists"
+else
+    fail "capability_module plugin" "not found in $MODULES_DIR"
+fi
+
+SEQUENCER_UP=false
+if curl -s --max-time 2 "$SEQUENCER_URL" -d '{"jsonrpc":"2.0","method":"get_program_ids","params":{},"id":1}' >/dev/null 2>&1; then
+    SEQUENCER_UP=true
+    pass "sequencer is reachable at $SEQUENCER_URL"
+else
+    skip "sequencer reachability" "not running at $SEQUENCER_URL"
+fi
+
+echo ""
+
+# ── Test 1: logoscore --call version() ─────────────────────────────────────────
+
+echo "── Test 1: logoscore --call version() (full plugin stack) ──"
+
+cleanup_logoscore() {
+    pkill -f "logoscore.*modules-dir" 2>/dev/null || true
+    pkill -f "logos_host" 2>/dev/null || true
+    sleep 0.5
+}
+
+# Kill any lingering processes first
+cleanup_logoscore
+
+VERSION_OUTPUT=$(QT_QPA_PLATFORM=offscreen timeout 30 "$LOGOSCORE" \
+    --modules-dir "$MODULES_DIR" \
+    --load-modules lez_multisig_module \
+    --call "lez_multisig_module.version()" 2>&1 || true)
+
+cleanup_logoscore
+
+if echo "$VERSION_OUTPUT" | grep -q "Method call successful. Result: 0.1.0"; then
+    pass "logoscore --call version() returned 0.1.0"
+else
+    fail "logoscore --call version()" "unexpected output"
+    echo "    Output (last 5 lines):"
+    echo "$VERSION_OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+echo ""
+
+# ── Test 2: logoscore --call getState() (full plugin → FFI → network) ─────────
+
+echo "── Test 2: logoscore --call getState() (plugin → FFI path) ──"
+
+ARGS_FILE=$(mktemp /tmp/logoscore_test_XXXXXX.json)
+cat > "$ARGS_FILE" <<'JSONEOF'
+{"sequencer_url":"http://127.0.0.1:3040","wallet_path":"/tmp","program_id_hex":"0x0000000000000000000000000000000000000000000000000000000000000001","create_key":"0x0000000000000000000000000000000000000000000000000000000000000001"}
+JSONEOF
+
+cleanup_logoscore
+
+GETSTATE_OUTPUT=$(QT_QPA_PLATFORM=offscreen timeout 30 "$LOGOSCORE" \
+    --modules-dir "$MODULES_DIR" \
+    --load-modules lez_multisig_module \
+    --call "lez_multisig_module.getState(@$ARGS_FILE)" 2>&1 || true)
+
+cleanup_logoscore
+rm -f "$ARGS_FILE"
+
+if echo "$GETSTATE_OUTPUT" | grep -q "Method call successful"; then
+    RESULT_LINE=$(echo "$GETSTATE_OUTPUT" | grep "Method call successful")
+    if echo "$RESULT_LINE" | grep -q '"success"'; then
+        pass "logoscore --call getState() got success response from FFI"
+    elif echo "$RESULT_LINE" | grep -q '"error"'; then
+        # Expected when sequencer is down — still proves the full path works
+        pass "logoscore --call getState() reached FFI (got expected error: sequencer down)"
+    else
+        pass "logoscore --call getState() got a response from FFI"
+    fi
+else
+    fail "logoscore --call getState()" "no Method call successful in output"
+    echo "    Output (last 5 lines):"
+    echo "$GETSTATE_OUTPUT" | tail -5 | sed 's/^/      /'
+fi
+
+echo ""
+
+# ── Test 3: Direct FFI via Python ctypes ───────────────────────────────────────
+
+echo "── Test 3: Direct FFI via Python ctypes ──"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "Python ctypes tests" "python3 not found"
+else
+    FFI_TEST_OUTPUT=$(python3 -c "
+import ctypes, json, sys
+
+lib = ctypes.CDLL('$MULTISIG_FFI')
+
+# Test version
+lib.lez_multisig_version.restype = ctypes.c_char_p
+ver = lib.lez_multisig_version()
+ver_str = ver.decode()
+print(f'version={ver_str}')
+
+# Test IDL retrieval
+lib.lez_multisig_get_idl.restype = ctypes.c_char_p
+idl_raw = lib.lez_multisig_get_idl()
+idl = json.loads(idl_raw.decode())
+print(f'idl_name={idl.get(\"name\", \"\")}')
+print(f'idl_instructions={len(idl.get(\"instructions\", []))}')
+
+# Test getState (will return error without sequencer, proves FFI path)
+lib.lez_multisig_get_state.restype = ctypes.c_char_p
+lib.lez_multisig_get_state.argtypes = [ctypes.c_char_p]
+args = json.dumps({
+    'sequencer_url': '$SEQUENCER_URL',
+    'wallet_path': '/tmp',
+    'program_id_hex': '0x0000000000000000000000000000000000000000000000000000000000000001',
+    'create_key': '0x0000000000000000000000000000000000000000000000000000000000000001'
+})
+result = lib.lez_multisig_get_state(args.encode())
+result_json = json.loads(result.decode())
+print(f'getstate_success={result_json.get(\"success\", False)}')
+print(f'getstate_has_response=true')
+if not result_json.get('success'):
+    print(f'getstate_error={result_json.get(\"error\", \"\")}')
+" 2>&1)
+
+    if echo "$FFI_TEST_OUTPUT" | grep -q "version=0.1.0"; then
+        pass "FFI lez_multisig_version() = 0.1.0"
+    else
+        fail "FFI version" "unexpected version"
+    fi
+
+    if echo "$FFI_TEST_OUTPUT" | grep -q "idl_name=multisig_program"; then
+        pass "FFI lez_multisig_get_idl() returned valid IDL"
+    else
+        fail "FFI get_idl" "unexpected IDL name"
+    fi
+
+    IDL_INSTR=$(echo "$FFI_TEST_OUTPUT" | grep "idl_instructions=" | cut -d= -f2)
+    if [[ "$IDL_INSTR" -gt 0 ]]; then
+        pass "FFI IDL has $IDL_INSTR instructions defined"
+    else
+        fail "FFI IDL instructions" "expected >0, got $IDL_INSTR"
+    fi
+
+    if echo "$FFI_TEST_OUTPUT" | grep -q "getstate_has_response=true"; then
+        if echo "$FFI_TEST_OUTPUT" | grep -q "getstate_success=True"; then
+            pass "FFI getState() returned success (sequencer is up)"
+        elif echo "$FFI_TEST_OUTPUT" | grep -q "getstate_error="; then
+            pass "FFI getState() reached sequencer layer (expected error: sequencer down)"
+        fi
+    else
+        fail "FFI getState()" "no response received"
+    fi
+fi
+
+echo ""
+
+# ── Test 4: Registry FFI (if available) ───────────────────────────────────────
+
+echo "── Test 4: Registry FFI ──"
+
+# Find registry FFI lib via ldd on the registry module
+REGISTRY_MODULE_SO="$HOME/logos-lez-registry-module/result/lib/liblez_registry_module.so"
+REGISTRY_FFI_SO=""
+
+if [[ -f "$REGISTRY_MODULE_SO" ]]; then
+    # Try ldd first, fall back to nix-store closure search
+    REGISTRY_FFI_SO=$(ldd "$REGISTRY_MODULE_SO" 2>/dev/null | grep liblez_registry_ffi | awk '{print $3}' || true)
+    if [[ -z "$REGISTRY_FFI_SO" ]] && command -v nix-store >/dev/null 2>&1; then
+        REGISTRY_FFI_SO=$(nix-store -qR "$HOME/logos-lez-registry-module/result" 2>/dev/null \
+            | while read -r p; do
+                if [[ -f "$p/lib/liblez_registry_ffi.so" ]]; then
+                    echo "$p/lib/liblez_registry_ffi.so"
+                    break
+                fi
+            done || true)
+    fi
+fi
+
+if [[ -n "$REGISTRY_FFI_SO" && -f "$REGISTRY_FFI_SO" ]]; then
+    REG_TEST_OUTPUT=$(python3 -c "
+import ctypes, json
+
+lib = ctypes.CDLL('$REGISTRY_FFI_SO')
+lib.lez_registry_version.restype = ctypes.c_char_p
+ver = lib.lez_registry_version()
+print(f'registry_version={ver.decode()}')
+
+lib.lez_registry_list.restype = ctypes.c_char_p
+lib.lez_registry_list.argtypes = [ctypes.c_char_p]
+args = json.dumps({'sequencer_url': '$SEQUENCER_URL', 'registry_program_id': '0x0000000000000000000000000000000000000000000000000000000000000001'})
+result = lib.lez_registry_list(args.encode())
+result_json = json.loads(result.decode())
+print(f'registry_list_has_response=true')
+print(f'registry_list_success={result_json.get(\"success\", False)}')
+" 2>&1)
+
+    if echo "$REG_TEST_OUTPUT" | grep -q "registry_version="; then
+        REG_VER=$(echo "$REG_TEST_OUTPUT" | grep "registry_version=" | cut -d= -f2)
+        pass "Registry FFI version = $REG_VER"
+    else
+        fail "Registry FFI version" "could not get version"
+    fi
+
+    if echo "$REG_TEST_OUTPUT" | grep -q "registry_list_has_response=true"; then
+        pass "Registry FFI list() returned structured response"
+    else
+        fail "Registry FFI list" "no response"
+    fi
+else
+    skip "Registry FFI tests" "liblez_registry_ffi.so not found"
+fi
+
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "============================================"
+echo "  Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
The C header (include/lez_multisig.h) documented the program ID field as `multisig_program_id` but the Rust FFI implementation expects `program_id_hex`. This caused silent failures when calling FFI functions from C/Qt code.

Found during headless test suite work (PR #9).